### PR TITLE
fix: repair dead CTA anchors, missing images and the Ads conversion label

### DIFF
--- a/anil.html
+++ b/anil.html
@@ -21,14 +21,14 @@
     <meta property="og:url" content="https://verlyvidracaria.com/anil.html">
     <meta property="og:title" content="Vidraçaria em Anil RJ | Box Blindex e Vidros Temperados">
     <meta property="og:description" content="Especialista em vidros temperados, box blindex, cortinas de vidro em Anil. Atendimento rápido e qualidade garantida. Orçamento grátis!">
-    <meta property="og:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta property="og:image" content="https://verlyvidracaria.com/img/logo.png">
     <meta property="og:locale" content="pt_BR">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Vidraçaria em Anil RJ | Verly Vidraçaria">
     <meta name="twitter:description" content="Box Blindex, Vidros Temperados e Cortinas de Vidro em Anil. Orçamento grátis!">
-    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo.png">
 
     <!-- Geo Tags -->
     <meta name="geo.region" content="BR-RJ">
@@ -62,7 +62,7 @@
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
       "name": "Verly Vidraçaria - Anil",
-      "image": "https://verlyvidracaria.com/img/logo-verly.png",
+      "image": "https://verlyvidracaria.com/img/logo.png",
       "description": "Vidraçaria especializada em box blindex, vidros temperados, cortinas de vidro e esquadrias de alumínio em Anil, Rio de Janeiro. Atendimento rápido, orçamento grátis e equipe especializada.",
       "@id": "https://verlyvidracaria.com/anil.html",
       "url": "https://verlyvidracaria.com/anil.html",
@@ -220,13 +220,13 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#portfolio">Nossos Serviços</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#servicos">Nossos Serviços</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#about">Quem Somos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#diferenciais">Quem Somos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contact">Orçamentos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contato">Orçamentos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
                         <a class="nav-link py-3 px-0 px-lg-3 rounded" href="blog.html">Blog</a>
@@ -277,7 +277,7 @@
                         <li class="mb-3"><i class="fas fa-star text-warning mr-2"></i> Garantia em todos os serviços</li>
                     </ul>
                     <div class="text-center mt-5">
-                        <a href="index.html#contact" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
+                        <a href="index.html#contato" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
                     </div>
                 </div>
             </div>

--- a/barra-da-tijuca.html
+++ b/barra-da-tijuca.html
@@ -63,7 +63,7 @@
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
       "name": "Verly Vidraçaria - Barra da Tijuca",
-      "image": "https://verlyvidracaria.com/img/logo-verly.png",
+      "image": "https://verlyvidracaria.com/img/logo.png",
       "description": "Vidraçaria especializada em box blindex, vidros temperados, cortinas de vidro e esquadrias de alumínio na Barra da Tijuca, Rio de Janeiro. Atendimento rápido, orçamento grátis e equipe especializada.",
       "@id": "https://verlyvidracaria.com/barra-da-tijuca.html",
       "url": "https://verlyvidracaria.com/barra-da-tijuca.html",
@@ -221,13 +221,13 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#portfolio">Nossos Serviços</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#servicos">Nossos Serviços</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#about">Quem Somos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#diferenciais">Quem Somos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contact">Orçamentos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contato">Orçamentos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
                         <a class="nav-link py-3 px-0 px-lg-3 rounded" href="blog.html">Blog</a>
@@ -282,7 +282,7 @@
                     </ul>
 
                     <div class="text-center mt-5">
-                        <a href="index.html#contact" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
+                        <a href="index.html#contato" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
                     </div>
                 </div>
             </div>

--- a/blog.html
+++ b/blog.html
@@ -70,13 +70,13 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#portfolio">Nossos Serviços</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#servicos">Nossos Serviços</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#about">Quem Somos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#diferenciais">Quem Somos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contact">Orçamentos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contato">Orçamentos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
                         <a class="nav-link py-3 px-0 px-lg-3 rounded active" href="blog.html">Blog</a>
@@ -110,7 +110,7 @@
                     <article class="blog-post">
                         <h3>Como escolher o vidro temperado ideal para sua casa</h3>
                         <div class="date">19 de Março, 2024</div>
-                        <img src="img/blog/vidro-temperado.jpg" alt="Vidro temperado para residências" class="img-fluid">
+                        <img src="img/portfolio/janela.jpg" alt="Vidro temperado para residências" class="img-fluid">
                         <p>O vidro temperado é uma excelente escolha para quem busca segurança e beleza em sua residência. Neste artigo, vamos explicar os diferentes tipos de vidros temperados e como escolher o ideal para cada ambiente...</p>
                         <a href="#" class="read-more">Ler mais →</a>
                     </article>
@@ -118,7 +118,7 @@
                     <article class="blog-post">
                         <h3>Manutenção e limpeza do box blindex: guia completo</h3>
                         <div class="date">18 de Março, 2024</div>
-                        <img src="img/blog/box-blindex.jpg" alt="Manutenção de box blindex" class="img-fluid">
+                        <img src="img/portfolio/box.jpg" alt="Manutenção de box blindex" class="img-fluid">
                         <p>O box blindex é uma solução prática e elegante para o banheiro, mas requer cuidados específicos para manter sua beleza e durabilidade. Aprenda as melhores práticas de limpeza e manutenção...</p>
                         <a href="#" class="read-more">Ler mais →</a>
                     </article>
@@ -126,7 +126,7 @@
                     <article class="blog-post">
                         <h3>Cortinas de vidro: tendências e dicas de instalação</h3>
                         <div class="date">17 de Março, 2024</div>
-                        <img src="img/blog/cortina-vidro.jpg" alt="Cortinas de vidro modernas" class="img-fluid">
+                        <img src="img/portfolio/cortina.jpg" alt="Cortinas de vidro modernas" class="img-fluid">
                         <p>As cortinas de vidro são uma tendência em arquitetura moderna. Descubra as últimas tendências e aprenda como escolher e instalar a cortina de vidro perfeita para seu espaço...</p>
                         <a href="#" class="read-more">Ler mais →</a>
                     </article>

--- a/campo-grande.html
+++ b/campo-grande.html
@@ -21,14 +21,14 @@
     <meta property="og:url" content="https://verlyvidracaria.com/campo-grande.html">
     <meta property="og:title" content="Vidraçaria em Campo Grande RJ | Box Blindex e Vidros Temperados">
     <meta property="og:description" content="Especialista em vidros temperados, box blindex, cortinas de vidro em Campo Grande. Maior bairro da Zona Oeste. Orçamento grátis!">
-    <meta property="og:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta property="og:image" content="https://verlyvidracaria.com/img/logo.png">
     <meta property="og:locale" content="pt_BR">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Vidraçaria em Campo Grande RJ | Verly Vidraçaria">
     <meta name="twitter:description" content="Box Blindex, Vidros Temperados e Cortinas de Vidro em Campo Grande. Orçamento grátis!">
-    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo.png">
 
     <!-- Geo Tags -->
     <meta name="geo.region" content="BR-RJ">
@@ -64,7 +64,7 @@
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
       "name": "Verly Vidraçaria - Campo Grande",
-      "image": "https://verlyvidracaria.com/img/logo-verly.png",
+      "image": "https://verlyvidracaria.com/img/logo.png",
       "description": "Vidraçaria especializada em box blindex, vidros temperados, cortinas de vidro e esquadrias de alumínio em Campo Grande, o maior bairro da Zona Oeste do Rio de Janeiro.",
       "@id": "https://verlyvidracaria.com/campo-grande.html",
       "url": "https://verlyvidracaria.com/campo-grande.html",
@@ -204,13 +204,13 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#portfolio">Nossos Serviços</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#servicos">Nossos Serviços</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#about">Quem Somos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#diferenciais">Quem Somos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contact">Orçamentos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contato">Orçamentos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
                         <a class="nav-link py-3 px-0 px-lg-3 rounded" href="blog.html">Blog</a>
@@ -261,7 +261,7 @@
                         <li class="mb-3"><i class="fas fa-star text-warning mr-2"></i> Garantia em todos os serviços</li>
                     </ul>
                     <div class="text-center mt-5">
-                        <a href="index.html#contact" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
+                        <a href="index.html#contato" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
                     </div>
                 </div>
             </div>

--- a/freguesia-de-jacarepagua.html
+++ b/freguesia-de-jacarepagua.html
@@ -19,14 +19,14 @@
     <meta property="og:url" content="https://verlyvidracaria.com/freguesia-de-jacarepagua.html">
     <meta property="og:title" content="Vidraçaria na Freguesia de Jacarepaguá RJ | Box Blindex e Vidros Temperados">
     <meta property="og:description" content="Especialista em vidros temperados, box blindex, cortinas de vidro na Freguesia de Jacarepaguá. Atendimento rápido e qualidade garantida. Orçamento grátis!">
-    <meta property="og:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta property="og:image" content="https://verlyvidracaria.com/img/logo.png">
     <meta property="og:locale" content="pt_BR">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Vidraçaria na Freguesia de Jacarepaguá RJ | Verly Vidraçaria">
     <meta name="twitter:description" content="Box Blindex, Vidros Temperados e Cortinas de Vidro na Freguesia. Orçamento grátis!">
-    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo.png">
 
     <!-- Geo Tags -->
     <meta name="geo.region" content="BR-RJ">
@@ -60,7 +60,7 @@
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
       "name": "Verly Vidraçaria - Freguesia de Jacarepaguá",
-      "image": "https://verlyvidracaria.com/img/logo-verly.png",
+      "image": "https://verlyvidracaria.com/img/logo.png",
       "description": "Vidraçaria especializada em box blindex, vidros temperados, cortinas de vidro e esquadrias de alumínio na Freguesia de Jacarepaguá, Rio de Janeiro. Atendimento rápido, orçamento grátis e equipe especializada.",
       "@id": "https://verlyvidracaria.com/freguesia-de-jacarepagua.html",
       "url": "https://verlyvidracaria.com/freguesia-de-jacarepagua.html",
@@ -218,13 +218,13 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#portfolio">Nossos Serviços</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#servicos">Nossos Serviços</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#about">Quem Somos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#diferenciais">Quem Somos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contact">Orçamentos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contato">Orçamentos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
                         <a class="nav-link py-3 px-0 px-lg-3 rounded" href="blog.html">Blog</a>
@@ -275,7 +275,7 @@
                         <li class="mb-3"><i class="fas fa-star text-warning mr-2"></i> Garantia em todos os serviços</li>
                     </ul>
                     <div class="text-center mt-5">
-                        <a href="index.html#contact" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
+                        <a href="index.html#contato" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
                     </div>
                 </div>
             </div>

--- a/gardenia-azul.html
+++ b/gardenia-azul.html
@@ -19,14 +19,14 @@
     <meta property="og:url" content="https://verlyvidracaria.com/gardenia-azul.html">
     <meta property="og:title" content="Vidraçaria em Gardênia Azul RJ | Box Blindex e Vidros Temperados">
     <meta property="og:description" content="Especialista em vidros temperados, box blindex, cortinas de vidro em Gardênia Azul. Atendimento rápido e qualidade garantida. Orçamento grátis!">
-    <meta property="og:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta property="og:image" content="https://verlyvidracaria.com/img/logo.png">
     <meta property="og:locale" content="pt_BR">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Vidraçaria em Gardênia Azul RJ | Verly Vidraçaria">
     <meta name="twitter:description" content="Box Blindex, Vidros Temperados e Cortinas de Vidro em Gardênia Azul. Orçamento grátis!">
-    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo.png">
 
     <!-- Geo Tags -->
     <meta name="geo.region" content="BR-RJ">
@@ -60,7 +60,7 @@
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
       "name": "Verly Vidraçaria - Gardênia Azul",
-      "image": "https://verlyvidracaria.com/img/logo-verly.png",
+      "image": "https://verlyvidracaria.com/img/logo.png",
       "description": "Vidraçaria especializada em box blindex, vidros temperados, cortinas de vidro e esquadrias de alumínio em Gardênia Azul, Rio de Janeiro. Atendimento rápido, orçamento grátis e equipe especializada.",
       "@id": "https://verlyvidracaria.com/gardenia-azul.html",
       "url": "https://verlyvidracaria.com/gardenia-azul.html",
@@ -218,13 +218,13 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#portfolio">Nossos Serviços</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#servicos">Nossos Serviços</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#about">Quem Somos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#diferenciais">Quem Somos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contact">Orçamentos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contato">Orçamentos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
                         <a class="nav-link py-3 px-0 px-lg-3 rounded" href="blog.html">Blog</a>
@@ -275,7 +275,7 @@
                         <li class="mb-3"><i class="fas fa-star text-warning mr-2"></i> Garantia em todos os serviços</li>
                     </ul>
                     <div class="text-center mt-5">
-                        <a href="index.html#contact" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
+                        <a href="index.html#contato" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
                     </div>
                 </div>
             </div>

--- a/jacarepagua.html
+++ b/jacarepagua.html
@@ -21,14 +21,14 @@
     <meta property="og:url" content="https://verlyvidracaria.com/jacarepagua.html">
     <meta property="og:title" content="Vidraçaria em Jacarepaguá RJ | Box Blindex e Vidros Temperados">
     <meta property="og:description" content="Especialista em vidros temperados, box blindex, cortinas de vidro em Jacarepaguá. Atendimento rápido e qualidade garantida. Orçamento grátis!">
-    <meta property="og:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta property="og:image" content="https://verlyvidracaria.com/img/logo.png">
     <meta property="og:locale" content="pt_BR">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Vidraçaria em Jacarepaguá RJ | Verly Vidraçaria">
     <meta name="twitter:description" content="Box Blindex, Vidros Temperados e Cortinas de Vidro em Jacarepaguá. Orçamento grátis!">
-    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo.png">
 
     <!-- Geo Tags -->
     <meta name="geo.region" content="BR-RJ">
@@ -62,7 +62,7 @@
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
       "name": "Verly Vidraçaria - Jacarepaguá",
-      "image": "https://verlyvidracaria.com/img/logo-verly.png",
+      "image": "https://verlyvidracaria.com/img/logo.png",
       "description": "Vidraçaria especializada em box blindex, vidros temperados, cortinas de vidro e esquadrias de alumínio em Jacarepaguá, Rio de Janeiro. Atendimento rápido, orçamento grátis e equipe especializada.",
       "@id": "https://verlyvidracaria.com/jacarepagua.html",
       "url": "https://verlyvidracaria.com/jacarepagua.html",
@@ -228,13 +228,13 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#portfolio">Nossos Serviços</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#servicos">Nossos Serviços</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#about">Quem Somos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#diferenciais">Quem Somos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contact">Orçamentos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contato">Orçamentos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
                         <a class="nav-link py-3 px-0 px-lg-3 rounded" href="blog.html">Blog</a>
@@ -286,7 +286,7 @@
                         <li class="mb-3"><i class="fas fa-star text-warning mr-2"></i> Garantia em todos os serviços</li>
                     </ul>
                     <div class="text-center mt-5">
-                        <a href="index.html#contact" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
+                        <a href="index.html#contato" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
                     </div>
                 </div>
             </div>

--- a/js/app.js
+++ b/js/app.js
@@ -5,6 +5,18 @@
  */
 
 // ============================================================================
+// GOOGLE ADS — CONVERSION LABEL
+// ============================================================================
+// Preencher com o label da ação de conversão no Google Ads
+// (Ferramentas → Conversões → a ação → "Instalar a tag manualmente":
+//  send_to: 'AW-17336857529/XXXXXXXXXXXXXXXXX' — copiar só a parte depois da barra).
+// Enquanto estiver vazio, NENHUMA conversão é enviada: o valor antigo era o
+// literal 'CONVERSION_ID', que o Ads descarta silenciosamente — a campanha ficava
+// sem sinal de conversão e ninguém percebia.
+const ADS_CONVERSION_ID = 'AW-17336857529';
+const ADS_CONVERSION_LABEL = '';
+
+// ============================================================================
 // GOOGLE ANALYTICS 4 (GA4) TRACKING UTILITIES
 // ============================================================================
 
@@ -497,11 +509,15 @@ async function handleFormSubmit(event) {
         
         // Track Google Ads conversion
         if (typeof gtag !== 'undefined' && apiSuccess) {
-            gtag('event', 'conversion', {
-                'send_to': 'AW-17336857529/CONVERSION_ID',
-                'value': 1.0,
-                'currency': 'BRL'
-            });
+            if (ADS_CONVERSION_LABEL) {
+                gtag('event', 'conversion', {
+                    'send_to': `${ADS_CONVERSION_ID}/${ADS_CONVERSION_LABEL}`,
+                    'value': 1.0,
+                    'currency': 'BRL'
+                });
+            } else {
+                console.warn('⚠️ ADS_CONVERSION_LABEL vazio — conversão do Google Ads NÃO enviada (o lead foi registrado normalmente).');
+            }
         }
         
         // Reset form

--- a/obrigado.html
+++ b/obrigado.html
@@ -48,13 +48,13 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item mx-0 mx-lg-1">
-              <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#portfolio">Nossos Serviços</a>
+              <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#servicos">Nossos Serviços</a>
             </li>
             <li class="nav-item mx-0 mx-lg-1">
-              <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#about">Quem Somos</a>
+              <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#diferenciais">Quem Somos</a>
             </li>
             <li class="nav-item mx-0 mx-lg-1">
-              <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contact">Orçamentos</a>
+              <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contato">Orçamentos</a>
             </li>
             <li class="nav-item mx-0 mx-lg-1">
               <a class="nav-link py-3 px-0 px-lg-3 rounded" href="blog.html">Blog</a>

--- a/pechincha.html
+++ b/pechincha.html
@@ -21,14 +21,14 @@
     <meta property="og:url" content="https://verlyvidracaria.com/pechincha.html">
     <meta property="og:title" content="Vidraçaria em Pechincha RJ | Box Blindex e Vidros Temperados">
     <meta property="og:description" content="Especialista em vidros temperados, box blindex, cortinas de vidro em Pechincha. Atendimento rápido e qualidade garantida. Orçamento grátis!">
-    <meta property="og:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta property="og:image" content="https://verlyvidracaria.com/img/logo.png">
     <meta property="og:locale" content="pt_BR">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Vidraçaria em Pechincha RJ | Verly Vidraçaria">
     <meta name="twitter:description" content="Box Blindex, Vidros Temperados e Cortinas de Vidro em Pechincha. Orçamento grátis!">
-    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo.png">
 
     <!-- Geo Tags -->
     <meta name="geo.region" content="BR-RJ">
@@ -62,7 +62,7 @@
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
       "name": "Verly Vidraçaria - Pechincha",
-      "image": "https://verlyvidracaria.com/img/logo-verly.png",
+      "image": "https://verlyvidracaria.com/img/logo.png",
       "description": "Vidraçaria especializada em box blindex, vidros temperados, cortinas de vidro e esquadrias de alumínio em Pechincha, Rio de Janeiro. Atendimento rápido, orçamento grátis e equipe especializada.",
       "@id": "https://verlyvidracaria.com/pechincha.html",
       "url": "https://verlyvidracaria.com/pechincha.html",
@@ -220,13 +220,13 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#portfolio">Nossos Serviços</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#servicos">Nossos Serviços</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#about">Quem Somos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#diferenciais">Quem Somos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contact">Orçamentos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contato">Orçamentos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
                         <a class="nav-link py-3 px-0 px-lg-3 rounded" href="blog.html">Blog</a>
@@ -277,7 +277,7 @@
                         <li class="mb-3"><i class="fas fa-star text-warning mr-2"></i> Garantia em todos os serviços</li>
                     </ul>
                     <div class="text-center mt-5">
-                        <a href="index.html#contact" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
+                        <a href="index.html#contato" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
                     </div>
                 </div>
             </div>

--- a/realengo.html
+++ b/realengo.html
@@ -40,13 +40,13 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#portfolio">Nossos Serviços</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#servicos">Nossos Serviços</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#about">Quem Somos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#diferenciais">Quem Somos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contact">Orçamentos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contato">Orçamentos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
                         <a class="nav-link py-3 px-0 px-lg-3 rounded" href="blog.html">Blog</a>
@@ -97,7 +97,7 @@
                         <li class="mb-3"><i class="fas fa-star text-warning mr-2"></i> Garantia em todos os serviços</li>
                     </ul>
                     <div class="text-center mt-5">
-                        <a href="index.html#contact" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
+                        <a href="index.html#contato" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
                     </div>
                 </div>
             </div>

--- a/recreio-dos-bandeirantes.html
+++ b/recreio-dos-bandeirantes.html
@@ -21,14 +21,14 @@
     <meta property="og:url" content="https://verlyvidracaria.com/recreio-dos-bandeirantes.html">
     <meta property="og:title" content="Vidraçaria no Recreio dos Bandeirantes RJ | Box Blindex e Vidros Temperados">
     <meta property="og:description" content="Especialista em vidros temperados, box blindex, cortinas de vidro no Recreio dos Bandeirantes. Atendimento rápido e qualidade garantida. Orçamento grátis!">
-    <meta property="og:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta property="og:image" content="https://verlyvidracaria.com/img/logo.png">
     <meta property="og:locale" content="pt_BR">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Vidraçaria no Recreio dos Bandeirantes RJ | Verly Vidraçaria">
     <meta name="twitter:description" content="Box Blindex, Vidros Temperados e Cortinas de Vidro no Recreio dos Bandeirantes. Orçamento grátis!">
-    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo.png">
 
     <!-- Geo Tags -->
     <meta name="geo.region" content="BR-RJ">
@@ -62,7 +62,7 @@
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
       "name": "Verly Vidraçaria - Recreio dos Bandeirantes",
-      "image": "https://verlyvidracaria.com/img/logo-verly.png",
+      "image": "https://verlyvidracaria.com/img/logo.png",
       "description": "Vidraçaria especializada em box blindex, vidros temperados, cortinas de vidro e esquadrias de alumínio no Recreio dos Bandeirantes, Rio de Janeiro. Atendimento rápido, orçamento grátis e equipe especializada.",
       "@id": "https://verlyvidracaria.com/recreio-dos-bandeirantes.html",
       "url": "https://verlyvidracaria.com/recreio-dos-bandeirantes.html",
@@ -220,13 +220,13 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#portfolio">Nossos Serviços</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#servicos">Nossos Serviços</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#about">Quem Somos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#diferenciais">Quem Somos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contact">Orçamentos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contato">Orçamentos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
                         <a class="nav-link py-3 px-0 px-lg-3 rounded" href="blog.html">Blog</a>
@@ -277,7 +277,7 @@
                         <li class="mb-3"><i class="fas fa-star text-warning mr-2"></i> Garantia em todos os serviços</li>
                     </ul>
                     <div class="text-center mt-5">
-                        <a href="index.html#contact" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
+                        <a href="index.html#contato" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
                     </div>
                 </div>
             </div>

--- a/vargem-grande.html
+++ b/vargem-grande.html
@@ -21,14 +21,14 @@
     <meta property="og:url" content="https://verlyvidracaria.com/vargem-grande.html">
     <meta property="og:title" content="Vidraçaria em Vargem Grande RJ | Box Blindex e Vidros Temperados">
     <meta property="og:description" content="Especialista em vidros temperados, box blindex, cortinas de vidro em Vargem Grande. Atendimento rápido e qualidade garantida. Orçamento grátis!">
-    <meta property="og:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta property="og:image" content="https://verlyvidracaria.com/img/logo.png">
     <meta property="og:locale" content="pt_BR">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Vidraçaria em Vargem Grande RJ | Verly Vidraçaria">
     <meta name="twitter:description" content="Box Blindex, Vidros Temperados e Cortinas de Vidro em Vargem Grande. Orçamento grátis!">
-    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo.png">
 
     <!-- Geo Tags -->
     <meta name="geo.region" content="BR-RJ">
@@ -62,7 +62,7 @@
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
       "name": "Verly Vidraçaria - Vargem Grande",
-      "image": "https://verlyvidracaria.com/img/logo-verly.png",
+      "image": "https://verlyvidracaria.com/img/logo.png",
       "description": "Vidraçaria especializada em box blindex, vidros temperados, cortinas de vidro e esquadrias de alumínio em Vargem Grande, Rio de Janeiro. Atendimento rápido, orçamento grátis e equipe especializada.",
       "@id": "https://verlyvidracaria.com/vargem-grande.html",
       "url": "https://verlyvidracaria.com/vargem-grande.html",
@@ -220,13 +220,13 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#portfolio">Nossos Serviços</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#servicos">Nossos Serviços</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#about">Quem Somos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#diferenciais">Quem Somos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contact">Orçamentos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contato">Orçamentos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
                         <a class="nav-link py-3 px-0 px-lg-3 rounded" href="blog.html">Blog</a>
@@ -277,7 +277,7 @@
                         <li class="mb-3"><i class="fas fa-star text-warning mr-2"></i> Garantia em todos os serviços</li>
                     </ul>
                     <div class="text-center mt-5">
-                        <a href="index.html#contact" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
+                        <a href="index.html#contato" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
                     </div>
                 </div>
             </div>

--- a/vargem-pequena.html
+++ b/vargem-pequena.html
@@ -21,14 +21,14 @@
     <meta property="og:url" content="https://verlyvidracaria.com/vargem-pequena.html">
     <meta property="og:title" content="Vidraçaria em Vargem Pequena RJ | Box Blindex e Vidros Temperados">
     <meta property="og:description" content="Especialista em vidros temperados, box blindex, cortinas de vidro em Vargem Pequena. Atendimento rápido e qualidade garantida. Orçamento grátis!">
-    <meta property="og:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta property="og:image" content="https://verlyvidracaria.com/img/logo.png">
     <meta property="og:locale" content="pt_BR">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Vidraçaria em Vargem Pequena RJ | Verly Vidraçaria">
     <meta name="twitter:description" content="Box Blindex, Vidros Temperados e Cortinas de Vidro em Vargem Pequena. Orçamento grátis!">
-    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo-verly.png">
+    <meta name="twitter:image" content="https://verlyvidracaria.com/img/logo.png">
 
     <!-- Geo Tags -->
     <meta name="geo.region" content="BR-RJ">
@@ -62,7 +62,7 @@
       "@context": "https://schema.org",
       "@type": "LocalBusiness",
       "name": "Verly Vidraçaria - Vargem Pequena",
-      "image": "https://verlyvidracaria.com/img/logo-verly.png",
+      "image": "https://verlyvidracaria.com/img/logo.png",
       "description": "Vidraçaria especializada em box blindex, vidros temperados, cortinas de vidro e esquadrias de alumínio em Vargem Pequena, Rio de Janeiro. Atendimento rápido, orçamento grátis e equipe especializada.",
       "@id": "https://verlyvidracaria.com/vargem-pequena.html",
       "url": "https://verlyvidracaria.com/vargem-pequena.html",
@@ -220,13 +220,13 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#portfolio">Nossos Serviços</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#servicos">Nossos Serviços</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#about">Quem Somos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#diferenciais">Quem Somos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
-                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contact">Orçamentos</a>
+                        <a class="nav-link py-3 px-0 px-lg-3 rounded" href="index.html#contato">Orçamentos</a>
                     </li>
                     <li class="nav-item mx-0 mx-lg-1">
                         <a class="nav-link py-3 px-0 px-lg-3 rounded" href="blog.html">Blog</a>
@@ -277,7 +277,7 @@
                         <li class="mb-3"><i class="fas fa-star text-warning mr-2"></i> Garantia em todos os serviços</li>
                     </ul>
                     <div class="text-center mt-5">
-                        <a href="index.html#contact" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
+                        <a href="index.html#contato" class="btn btn-primary btn-lg">Solicitar Orçamento</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Three P0s found while auditing the site against a landing-page conversion checklist. All three verified against `origin/gh-pages` (what is actually deployed), not the local working tree.

## 1. The neighborhood pages send their traffic nowhere

The 11 bairro pages have no form and no `wa.me` link. Their only CTA is `index.html#contact` — plus `#portfolio` and `#about` in the nav. None of those ids exist: the index refactor (`2b8fbd4`) renamed the sections to `#contato`, `#servicos`, `#diferenciais`, `#depoimentos`.

So every organic visitor who searched "vidraçaria em Jacarepaguá", landed on the page and clicked **Solicitar Orçamento** was dropped at the top of the homepage, with the form four screens below and nothing telling them to scroll.

**50 references across 13 pages** (the 11 bairros + `blog.html` + `obrigado.html`), remapped:
| antes | depois |
|---|---|
| `index.html#contact` | `index.html#contato` |
| `index.html#portfolio` | `index.html#servicos` |
| `index.html#about` | `index.html#diferenciais` |

`#about` → `#diferenciais` is a judgement call: the link says "Quem Somos" and the closest surviving section is "Por Que Escolher a Verly?". Say the word and I point it elsewhere.

## 2. Google Ads has never received a conversion

`js/app.js:501` fired with the literal placeholder as its label:

```js
'send_to': 'AW-17336857529/CONVERSION_ID',
```

Ads discards an unknown label silently, so the account has been running with zero conversion signal — no campaign optimisation, no cost-per-lead. The real label lives in the Ads console, not in this repo, so this PR cannot fill it. What it does instead: promotes it to a named constant, skips the call while it is empty, and logs a warning. **One line to turn on** (`ADS_CONVERSION_LABEL`), and no more silent failure.

## 3. Two sets of missing images

`img/logo-verly.png` is referenced by 10 bairro pages but has never existed here — the file is `img/logo.png`. It sits in `og:image`, `twitter:image` and the LocalBusiness schema, so what broke is **social sharing previews and rich results**, not the visible page. Repointed.

The three `img/blog/*.jpg` files never existed either, and those are real `<img>` tags — visibly broken on `blog.html`. Repointed to existing portfolio photos matching each post (`janela.jpg`, `box.jpg`, `cortina.jpg`). Swap them for real post images whenever there are some.

## Checks

- zero remaining `index.html#(contact|portfolio|about)` references
- every `img/...` path referenced in HTML/CSS/JS now resolves to a file that exists
- `node --check js/app.js` clean; all 17 pages parse

## Not in this PR

The bairro pages still have no form and no WhatsApp button of their own — this only repairs the path to the homepage form. Putting a form on each page is the bigger win and a separate change.