### PR TITLE
fix(blog): point the stale verlyvidros.com references at the live domain

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -12,8 +12,8 @@
     <meta property="og:title" content="Blog - Dicas e Informações sobre Vidros e Alumínio | Verly Vidraçaria">
     <meta property="og:description" content="Blog Verly Vidraçaria - Dicas e informações sobre vidros temperados, box blindex, cortinas de vidro e soluções em alumínio para sua casa ou empresa.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://verlyvidros.com/blog.html">
-    <meta property="og:image" content="https://verlyvidros.com/img/portfolio/cortina.jpg">
+    <meta property="og:url" content="https://verlyvidracaria.com/blog.html">
+    <meta property="og:image" content="https://verlyvidracaria.com/img/portfolio/cortina.jpg">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta property="og:site_name" content="Verly Vidraçaria">
@@ -23,7 +23,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog - Dicas e Informações sobre Vidros e Alumínio | Verly Vidraçaria">
     <meta name="twitter:description" content="Blog Verly Vidraçaria - Dicas e informações sobre vidros temperados, box blindex, cortinas de vidro e soluções em alumínio para sua casa ou empresa.">
-    <meta name="twitter:image" content="https://verlyvidros.com/img/portfolio/cortina.jpg">
+    <meta name="twitter:image" content="https://verlyvidracaria.com/img/portfolio/cortina.jpg">
     <link href="vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href="css/freelancer.min.css" rel="stylesheet">
@@ -154,7 +154,7 @@
                     <h4 class="text-uppercase mb-4">Contato</h4>
                     <p class="lead mb-0">(21) 98792-6578</p>
                     <p class="lead mb-0">(21) 3421-6066</p>
-                    <p class="lead mb-0">contato@verlyvidros.com</p>
+                    <p class="lead mb-0">contato@verlyvidracaria.com</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Found while validating #39 against the deployed site: every image reference on the live pages resolves 200 except one on `blog.html`, which points at **`verlyvidros.com`** — a domain with no DNS record (`dig +short verlyvidros.com A` returns nothing).

It is the only page in the repo carrying that domain; all others use `verlyvidracaria.com`.

| line | what | effect |
|---|---|---|
| 15 | `og:url` | share preview points at a dead domain |
| 16 | `og:image` | preview image never loads |
| 26 | `twitter:image` | same |
| 157 | `contato@verlyvidros.com` **printed in the footer** | anyone who writes to it gets a bounce |

Line 157 is the one that matters — it is a wrong contact address shown to visitors.

Four replacements, one file, no other change. `git grep verlyvidros` comes back empty afterwards.