### PR TITLE
feat: put the actual brand in the header instead of a stock icon

### DIFF
--- a/scripts/check-contrast.mjs
+++ b/scripts/check-contrast.mjs
@@ -35,6 +35,8 @@ const PAIRS = [
   ['Corpo de texto', 'gray', 'white', false],
   ['Títulos', 'dark', 'white', false],
   ['Estrelas de avaliação', 'star', 'white', false],
+  ['Marca — nome no cabeçalho', 'primary', 'white', false],
+  ['Marca — descritor "Vidraçaria"', 'secondary', 'white', false],
 ];
 
 const MIN = { normal: 4.5, large: 3.0 };

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -23,8 +23,17 @@ const quoteHref = `${contactBase}#contato`;
 ---
 
 <nav class="navbar">
-  <a href={home ? '#' : '/index.html'} class="logo">
-    <Icon name="gem" /> Verly Vidraçaria
+  {/* Marca em duas linhas, espelhando a arquitetura da placa da loja: nome grande
+      + descritor em caixa alta espaçada abaixo. Antes aqui havia um ícone genérico
+      de diamante — a marca real não aparecia em lugar nenhum da página, só como
+      og:image. O peso 800 do Inter já está carregado, então isso não custa bytes.
+      Quando existir o SVG do letreiro redesenhado, troca-se este bloco por uma
+      <img> e mais nada muda. */}
+  <a href={home ? '#' : '/index.html'} class="logo" aria-label="Verly Vidraçaria — página inicial">
+    <span class="brand">
+      <span class="brand-name">Verly</span>
+      <span class="brand-sub">Vidraçaria</span>
+    </span>
   </a>
   <ul class="nav-menu">
     {links.map((l) => (

--- a/src/styles/index-inline.css
+++ b/src/styles/index-inline.css
@@ -880,3 +880,32 @@
     line-height: 1.4;
     opacity: 0.9;
 }
+
+/* Marca — duas linhas, como a placa: nome + descritor.
+   Sem itálico de propósito: a placa é inclinada, mas obter isso aqui exigiria
+   carregar o eixo itálico da fonte (mais um arquivo) ou usar oblíquo sintético,
+   que engorda mal os traços. O vínculo com a fachada vem da cor e da arquitetura
+   de duas linhas; a inclinação volta quando entrar o SVG. */
+.brand {
+    display: inline-flex;
+    flex-direction: column;
+    line-height: 1;
+}
+.brand-name {
+    font-size: 1.5rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    color: var(--primary);
+}
+.brand-sub {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--secondary);
+    margin-top: 0.15rem;
+}
+@media (max-width: 480px) {
+    .brand-name { font-size: 1.25rem; }
+    .brand-sub { font-size: 0.625rem; letter-spacing: 0.18em; }
+}


### PR DESCRIPTION
Item 2 do plano. O site rodava **três identidades ao mesmo tempo**:

| onde | o que é |
|---|---|
| `public/img/logo.png` | script fino e delicado, azure chapado — **nunca renderizado**, só `og:image` |
| placa da loja | itálico pesado com contorno |
| cabeçalho do site | ícone genérico de diamante do Font Awesome + nome em texto |

A marca que o cliente vê na rua não aparecia em lugar nenhum da página.

## O que muda

O cabeçalho passa a exibir um bloco de duas linhas espelhando a arquitetura da placa: o nome, e abaixo o descritor em caixa alta espaçada. Usa o peso 800 do Inter que a fonte variável **já carrega** — custo zero de bytes.

## Sem itálico, de propósito

Acompanhar a inclinação da placa exigiria carregar o eixo itálico da fonte — mais um arquivo, poucos dias depois de a gente cortar 180KB — ou usar oblíquo sintético, que engorda os traços de forma irregular. O vínculo com a fachada vem da **cor** (o matiz saiu da própria placa) e da estrutura de duas linhas. A inclinação volta quando entrar o SVG.

O bloco é um **slot**: quando existir o vetor redesenhado, vira uma `<img>` e nada mais muda.

## Contraste

Os dois pares novos entram no verificador, então não regridem em silêncio:

| | |
|---|---|
| nome `#0f5f9e` sobre branco | 6.66:1 |
| descritor `#1077cb` sobre branco | 4.64:1 (texto pequeno, mínimo 4.5) |

## Ainda pendente

A **reorganização para a regra dos 8 segundos** não está aqui — é trabalho separado, e mexe na ordem do conteúdo, então prefiro te mostrar a proposta antes de escrever.