### PR TITLE
fix: make the runtime CTAs actually render, click and stop covering the page

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -209,11 +209,13 @@ function showAlert(message, type = 'success') {
     } else {
         // Fallback to original behavior
         const alertDiv = document.getElementById('formAlert');
-        const iconClass = type === 'success' ? 'fa-check-circle' : 'fa-exclamation-circle';
-        
+        // Caractere no lugar do `<i class="fas fa-…">` que não desenha mais nada sem o
+        // Font Awesome. A cor de .form-alert.success/.error já diz o estado.
+        const icon = type === 'success' ? '✓' : '!';
+
         alertDiv.innerHTML = `
             <div class="form-alert ${type}">
-                <i class="fas ${iconClass}"></i>
+                <span aria-hidden="true">${icon}</span>
                 <span>${message}</span>
             </div>
         `;
@@ -415,7 +417,12 @@ async function handleFormSubmit(event) {
     const messageField = document.getElementById('message');
     const submitBtn = document.getElementById('submitBtn');
     const btnText = document.getElementById('btnText');
-    
+    // Guardar o rótulo que o servidor renderizou (com o SVG do ícone) em vez de
+    // reescrevê-lo à mão depois do envio: a versão escrita à mão trazia um
+    // `<i class="fas fa-paper-plane">`, que desde a saída do Font Awesome não desenha
+    // nada — o botão voltava do "Enviando..." sem ícone.
+    const btnTextInitialHTML = btnText.innerHTML;
+
     // Validate all fields
     let isValid = true;
     
@@ -590,12 +597,12 @@ async function handleFormSubmit(event) {
     } finally {
         // Reset button state (use ButtonLoader if available)
         if (typeof ButtonLoader !== 'undefined') {
+            // stop() já devolve o innerHTML inteiro do botão que start() guardou.
             ButtonLoader.stop(submitBtn);
-            btnText.innerHTML = '<i class="fas fa-paper-plane"></i> Solicitar Orçamento Grátis';
         } else {
             submitBtn.disabled = false;
             submitBtn.classList.remove('btn-loading');
-            btnText.innerHTML = '<i class="fas fa-paper-plane"></i> Solicitar Orçamento Grátis';
+            btnText.innerHTML = btnTextInitialHTML;
         }
     }
 }

--- a/public/js/ui-improvements.js
+++ b/public/js/ui-improvements.js
@@ -41,9 +41,7 @@ const ToastManager = {
                 <div class="toast-title">${this.getTitle(type)}</div>
                 <div class="toast-message">${message}</div>
             </div>
-            <button class="toast-close" aria-label="Fechar notificação">
-                <i class="fas fa-times"></i>
-            </button>
+            <button class="toast-close" aria-label="Fechar notificação">&times;</button>
         `;
         
         // Add close button handler
@@ -76,13 +74,19 @@ const ToastManager = {
     
     /**
      * Get icon for toast type
+     *
+     * Caractere, não ícone: aqui havia `<i class="fas fa-…">`, que virou retângulo
+     * vazio quando o Font Awesome saiu do site. O estado do toast já é dito três
+     * vezes — cor da borda, título ("Erro", "Atenção") e a própria mensagem —, então
+     * o desenho é redundância decorativa e não vale um path novo em icons.json. O
+     * glifo herda a cor de .toast.<tipo> .toast-icon como o <i> herdava.
      */
     getIcon(type) {
         const icons = {
-            success: '<i class="fas fa-check-circle"></i>',
-            error: '<i class="fas fa-exclamation-circle"></i>',
-            warning: '<i class="fas fa-exclamation-triangle"></i>',
-            info: '<i class="fas fa-info-circle"></i>'
+            success: '✓',
+            error: '✕',
+            warning: '!',
+            info: 'i'
         };
         return icons[type] || icons.info;
     },
@@ -157,13 +161,20 @@ const ValidationIcons = {
         
         field.classList.add('has-icon');
         
-        // Create icons
-        const successIcon = document.createElement('i');
-        successIcon.className = 'fas fa-check-circle form-validation-icon success-icon';
-        
-        const errorIcon = document.createElement('i');
-        errorIcon.className = 'fas fa-times-circle form-validation-icon error-icon';
-        
+        // Marca de validação em caractere. Eram dois <i class="fas fa-…"> por campo —
+        // 8 numa página com o formulário — e nenhum desenhava nada sem o Font Awesome:
+        // o campo ficava verde/vermelho e o selo ao lado, vazio. A cor continua vindo
+        // de .is-valid/.is-invalid, então o significado não depende do glifo.
+        const successIcon = document.createElement('span');
+        successIcon.className = 'form-validation-icon success-icon';
+        successIcon.setAttribute('aria-hidden', 'true');
+        successIcon.textContent = '✓';
+
+        const errorIcon = document.createElement('span');
+        errorIcon.className = 'form-validation-icon error-icon';
+        errorIcon.setAttribute('aria-hidden', 'true');
+        errorIcon.textContent = '✕';
+
         // Add after field
         field.parentElement.appendChild(successIcon);
         field.parentElement.appendChild(errorIcon);

--- a/public/js/whatsapp-cta.js
+++ b/public/js/whatsapp-cta.js
@@ -56,21 +56,29 @@ const WhatsAppCTA = {
     },
     
     /**
-     * Forçar abertura no WhatsApp Web ou App
-     * Desktop: WhatsApp Web
-     * Mobile: WhatsApp App (API)
+     * Link do WhatsApp com a mensagem já preenchida.
+     *
+     * Sempre wa.me: é ele que decide entre app instalado, WhatsApp Web e loja de
+     * aplicativos, e acerta em casos que sniffing de user agent não cobre (WhatsApp
+     * Desktop, tablet, navegador em modo desktop no celular). A versão anterior
+     * mandava todo desktop para web.whatsapp.com/send, o que joga quem não tem sessão
+     * ativa no navegador numa tela de QR code — no meio do clique de conversão.
      */
-    getWhatsAppWebURL(message = '') {
-        const encodedMessage = encodeURIComponent(message);
-        const deviceInfo = this.getDeviceInfo();
-        
-        if (deviceInfo.isMobile) {
-            // Mobile: usar API para abrir diretamente no app
-            return `https://api.whatsapp.com/send?phone=${this.phone}&text=${encodedMessage}`;
-        } else {
-            // Desktop: forçar WhatsApp Web
-            return `https://web.whatsapp.com/send?phone=${this.phone}&text=${encodedMessage}`;
-        }
+    waLink(message = '') {
+        return `https://wa.me/${this.phone}?text=${encodeURIComponent(message)}`;
+    },
+
+    /**
+     * Markup do ícone do WhatsApp, clonado do que a página já renderizou.
+     *
+     * O Font Awesome saiu na migração de assets, então `<i class="fab fa-whatsapp">`
+     * não desenha mais nada — era um botão de WhatsApp sem WhatsApp. O SVG do botão
+     * flutuante vem de src/data/icons.json via Icon.astro; clonar de lá mantém uma
+     * fonte de verdade só para o desenho e não repete o path dentro de /public.
+     */
+    iconHTML() {
+        const rendered = document.querySelector('.whatsapp-float svg.icon');
+        return rendered ? rendered.outerHTML : '';
     },
 
     /**
@@ -96,59 +104,24 @@ const WhatsAppCTA = {
      */
     init() {
         console.log('🚀 WhatsApp CTA Optimization iniciado');
-        
-        // 1. Atualizar todos os links existentes para WhatsApp Web
-        this.updateExistingLinks();
-        
-        // 2. Adicionar Sticky CTA após scroll
-        this.addStickyCTA();
-        
-        // 3. Adicionar CTAs inline nas seções de serviços
-        this.addServiceCTAs();
-        
-        // 4. Melhorar botão flutuante
-        this.enhanceFloatingButton();
-        
-        // 5. Track conversions
-        this.trackConversions();
-        
-        console.log('✅ Otimizações aplicadas');
-    },
 
-    /**
-     * Atualizar links existentes para WhatsApp Web
-     */
-    updateExistingLinks() {
-        // Selecionar TODOS os links de WhatsApp, incluindo os que já têm web.whatsapp.com
-        const whatsappLinks = document.querySelectorAll(
-            'a[href*="wa.me"], a[href*="whatsapp"], .whatsapp-float'
-        );
-        
-        whatsappLinks.forEach(link => {
-            // Extrair mensagem existente se houver
-            const currentHref = link.getAttribute('href');
-            
-            // Se não tiver href, pular
-            if (!currentHref) return;
-            
-            const textMatch = currentHref.match(/text=([^&]*)/);
-            const existingMessage = textMatch ? decodeURIComponent(textMatch[1]) : this.messages.floating;
-            
-            // Atualizar para WhatsApp Web
-            const newUrl = this.getWhatsAppWebURL(existingMessage);
-            link.setAttribute('href', newUrl);
-            
-            // Manter target para abrir em nova aba
-            link.setAttribute('target', '_blank');
-            link.setAttribute('rel', 'noopener noreferrer');
-            
-            // Log específico para botão flutuante
-            if (link.classList.contains('whatsapp-float')) {
-                console.log('✓ Botão flutuante atualizado:', newUrl);
-            }
-        });
-        
-        console.log(`✓ ${whatsappLinks.length} links atualizados para WhatsApp Web`);
+        // Os links que o Astro renderiza já saem prontos (src/data/site.ts). O que
+        // existia aqui era um passe reescrevendo TODOS eles para web.whatsapp.com;
+        // agora só os CTAs criados em runtime precisam de href.
+
+        // 1. Adicionar Sticky CTA após scroll
+        this.addStickyCTA();
+
+        // 2. Adicionar CTAs inline nas seções de serviços
+        this.addServiceCTAs();
+
+        // 3. Melhorar botão flutuante
+        this.enhanceFloatingButton();
+
+        // 4. Track conversions
+        this.trackConversions();
+
+        console.log('✅ Otimizações aplicadas');
     },
 
     /**
@@ -165,10 +138,12 @@ const WhatsAppCTA = {
                     <strong>🎉 Orçamento Grátis em 2 Horas!</strong>
                     <span>Fale com nossos especialistas agora</span>
                 </div>
-                <a href="${this.getWhatsAppWebURL(this.messages.urgente)}" 
+                <a href="${this.waLink(this.messages.urgente)}"
                    class="sticky-cta-button"
+                   target="_blank"
+                   rel="noopener noreferrer"
                    data-context="sticky-cta">
-                    <i class="fab fa-whatsapp"></i>
+                    ${this.iconHTML()}
                     <span>Chamar no WhatsApp</span>
                 </a>
             </div>
@@ -222,10 +197,10 @@ const WhatsAppCTA = {
                 
                 // Adicionar botão no card
                 const ctaButton = document.createElement('a');
-                ctaButton.href = this.getWhatsAppWebURL(service.message);
+                ctaButton.href = this.waLink(service.message);
                 ctaButton.className = 'service-whatsapp-cta';
                 ctaButton.innerHTML = `
-                    <i class="fab fa-whatsapp"></i>
+                    ${this.iconHTML()}
                     <span>Pedir Orçamento</span>
                 `;
                 ctaButton.dataset.context = `service-${service.name.toLowerCase().replace(/\s+/g, '-')}`;
@@ -246,10 +221,10 @@ const WhatsAppCTA = {
     enhanceFloatingButton() {
         const floatingBtn = document.querySelector('.whatsapp-float');
         if (!floatingBtn) return;
-        
-        // Atualizar URL
-        floatingBtn.href = this.getWhatsAppWebURL(this.messages.floating);
-        
+
+        // O href vem do servidor (CONTACT.whatsappFloat) e já é um wa.me com a
+        // mensagem certa — não há o que reescrever aqui.
+
         // Adicionar tooltip
         const tooltip = document.createElement('div');
         tooltip.className = 'whatsapp-float-tooltip';

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,6 +7,11 @@ interface Props {
 }
 const { home = false } = Astro.props;
 const base = home ? '' : '/index.html';
+
+// O site é estático: o ano sai do build, não do relógio do visitante. Fixo em 2024,
+// o rodapé anunciava um site abandonado há dois anos — em página de orçamento isso
+// vira dúvida sobre a loja ainda existir. Qualquer republicação atualiza.
+const year = new Date().getFullYear();
 ---
 
 <footer class="footer">
@@ -43,7 +48,7 @@ const base = home ? '' : '/index.html';
         <h4>Contato</h4>
         <p>
           <Icon name="whatsapp" />
-          <a href={CONTACT.whatsappWeb} class="footer-contact-link whatsapp-link" data-context="footer-whatsapp" data-track="footer_whatsapp_click">
+          <a href={CONTACT.whatsappFooter} target="_blank" rel="noopener noreferrer" class="footer-contact-link whatsapp-link" data-context="footer-whatsapp" data-track="footer_whatsapp_click">
             {CONTACT.mobileDisplay}
           </a>
           <br />
@@ -72,7 +77,7 @@ const base = home ? '' : '/index.html';
     </div>
 
     <div class="footer-bottom">
-      <p>&copy; 2024 Verly Vidraçaria. Todos os direitos reservados.</p>
+      <p>&copy; {year} Verly Vidraçaria. Todos os direitos reservados.</p>
     </div>
   </div>
 </footer>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -8,18 +8,27 @@ interface Props {
   home?: boolean;
   /** true quando a página tem o formulário — então #contato é local, não salta */
   hasForm?: boolean;
+  /** true quando a página tem a própria seção de serviços (#servicos) */
+  hasServices?: boolean;
+  /** true quando a página tem a própria seção de diferenciais (#diferenciais) */
+  hasDifferentials?: boolean;
 }
-const { home = false, hasForm = false } = Astro.props;
-const base = home ? '' : '/index.html';
-const contactBase = home || hasForm ? '' : '/index.html';
+const { home = false, hasForm = false, hasServices = false, hasDifferentials = false } = Astro.props;
+
+// Mesma regra para cada item: âncora local quando a seção existe AQUI, salto para o
+// index quando não existe. As páginas de bairro têm serviços, diferenciais e
+// formulário próprios — mandar o visitante para o index era tirá-lo de uma landing
+// page que já respondia à pergunta dele. Depoimentos só existem no index, então esse
+// continua saltando.
+const anchor = (id: string, isLocal: boolean) => `${home || isLocal ? '' : '/index.html'}#${id}`;
 
 const links = [
-  { href: `${base}#servicos`, label: 'Serviços' },
-  { href: `${base}#diferenciais`, label: 'Diferenciais' },
-  { href: `${base}#depoimentos`, label: 'Depoimentos' },
-  { href: `${contactBase}#contato`, label: 'Contato' },
+  { href: anchor('servicos', hasServices), label: 'Serviços' },
+  { href: anchor('diferenciais', hasDifferentials), label: 'Diferenciais' },
+  { href: anchor('depoimentos', false), label: 'Depoimentos' },
+  { href: anchor('contato', hasForm), label: 'Contato' },
 ];
-const quoteHref = `${contactBase}#contato`;
+const quoteHref = anchor('contato', hasForm);
 ---
 
 <nav class="navbar">

--- a/src/components/QuoteForm.astro
+++ b/src/components/QuoteForm.astro
@@ -1,6 +1,6 @@
 ---
 import Icon from '../components/Icon.astro';
-import { NEIGHBORHOOD_OPTIONS } from '../data/site';
+import { CONTACT, NEIGHBORHOOD_OPTIONS } from '../data/site';
 
 interface Props {
   /** Bairro da página — pré-seleciona a opção no <select>. A escolha segue editável:
@@ -33,16 +33,20 @@ const {
                         </div>
                         <div class="contact-item-content">
                             <strong>WhatsApp</strong>
-                            <p>(21) 98792-6578</p>
+                            <p>{CONTACT.mobileDisplay}</p>
                         </div>
                     </div>
+                    {/* Os dois campos mostravam o MESMO celular, os dois escritos à mão aqui:
+                        quem preferia ligar de um fixo tinha só um número de celular na tela,
+                        e o fixo da loja — que o rodapé já publica — não aparecia. Vindo de
+                        CONTACT não há como um número mudar e o outro ficar para trás. */}
                     <div class="contact-item">
                         <div class="contact-item-icon">
                             <Icon name="phone" />
                         </div>
                         <div class="contact-item-content">
                             <strong>Telefone</strong>
-                            <p>(21) 98792-6578</p>
+                            <p>{CONTACT.landlineDisplay}</p>
                         </div>
                     </div>
                     <div class="contact-item">

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -13,10 +13,15 @@ export const CONTACT = {
   landline: '+552134216066',
   landlineDisplay: '(21) 3421-6066',
   email: 'contato@verlyvidracaria.com',
-  whatsappWeb:
-    'https://web.whatsapp.com/send?phone=5521987926578&text=Ol%C3%A1%2C%20vim%20pelo%20site%20e%20gostaria%20de%20solicitar%20um%20or%C3%A7amento!',
+  // Todo link de WhatsApp passa por wa.me. É ele que escolhe entre o app instalado,
+  // o WhatsApp Web e a loja de aplicativos; apontar direto para web.whatsapp.com/send
+  // manda quem não tem sessão ativa no navegador para uma tela de QR code, o que
+  // custava o clique exatamente onde a intenção de compra era maior.
+  // O sufixo do nome é a origem do clique, não a plataforma de destino.
+  whatsappFooter:
+    'https://wa.me/5521987926578?text=Ol%C3%A1%2C%20vim%20pelo%20site%20e%20gostaria%20de%20solicitar%20um%20or%C3%A7amento!',
   whatsappFloat:
-    'https://web.whatsapp.com/send?phone=5521987926578&text=Ol%C3%A1%2C%20gostaria%20de%20solicitar%20um%20or%C3%A7amento%20para%20vidra%C3%A7aria!',
+    'https://wa.me/5521987926578?text=Ol%C3%A1%2C%20gostaria%20de%20solicitar%20um%20or%C3%A7amento%20para%20vidra%C3%A7aria!',
   whatsappDirect:
     'https://wa.me/5521987926578?text=Ol%C3%A1%2C%20gostaria%20de%20solicitar%20um%20or%C3%A7amento%20de%20vidra%C3%A7aria!',
   mapsUrl:

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -25,6 +25,10 @@ interface Props {
   home?: boolean;
   /** a página traz o formulário? decide se o nav aponta #contato local */
   hasForm?: boolean;
+  /** a página traz seção de serviços própria? decide se o nav aponta #servicos local */
+  hasServices?: boolean;
+  /** a página traz seção de diferenciais própria? idem para #diferenciais */
+  hasDifferentials?: boolean;
   bodyClass?: string;
   /** paridade: blog/obrigado/404/500 não carregam LocalBusiness hoje */
   schema?: boolean;
@@ -45,6 +49,8 @@ const {
   ogImage,
   home = false,
   hasForm = false,
+  hasServices = false,
+  hasDifferentials = false,
   bodyClass,
   schema = true,
   includeRating = true,
@@ -132,7 +138,7 @@ const ogImageUrl = ogImage ?? `${SITE_URL}${ogFallback.src}`;
   <body class={bodyClass}>
     <header class="header">
       <div class="container">
-        <Nav home={home} hasForm={hasForm} />
+        <Nav home={home} hasForm={hasForm} hasServices={hasServices} hasDifferentials={hasDifferentials} />
       </div>
     </header>
 

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -41,6 +41,8 @@ const faqSchema =
   ogImage={n.ogImage ?? undefined}
   includeRating={n.hasRating}
   hasForm={true}
+  hasServices={true}
+  hasDifferentials={true}
 >
   {faqSchema && (
     <script slot="head" type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
@@ -98,7 +100,10 @@ const faqSchema =
     </div>
   </section>
 
-  <section class="section">
+  {/* id local: o nav ancorava "Serviços" em /index.html#servicos mesmo aqui, onde a
+      seção existe — 3 dos 4 itens do menu levavam o visitante embora da página de
+      bairro em que ele acabou de chegar por busca local. */}
+  <section id="servicos" class="section">
     <div class="container">
       <h2 class="section-title">{n.sectionTitle}</h2>
       {n.intro.map((p) => <p class="section-subtitle">{p}</p>)}
@@ -120,7 +125,7 @@ const faqSchema =
     subtitle="Preencha e entraremos em contato em até 2 horas úteis. Sem compromisso."
   />
 
-  <section class="section why-choose">
+  <section id="diferenciais" class="section why-choose">
     <div class="container">
       <h2 class="section-title">Por que escolher a Verly em {n.name}?</h2>
       <div class="services-grid">

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -13,13 +13,24 @@ import Base from '../layouts/Base.astro';
 
 
     <!-- Blog Content -->
-    <section class="page-section">
+    {/* A página não tinha <h1> nenhum: o assunto vivia só no <title>, e cada post
+        abria em <h3> — hierarquia começando no terceiro nível. Agora o <h1> nomeia a
+        página e os posts são <h2>, sem pular degrau. A classe é `section` (e não
+        `page-section`, que morreu com o tema Bootstrap e hoje não estiliza nada) e o
+        padding do topo sai do token do cabeçalho: sem isso o <h1> nasce atrás do
+        header, que é fixo. */}
+    <section class="section" style="padding-top: calc(var(--header-height) + 3rem);">
         <div class="container">
+            <h1 class="section-title">Dicas sobre Vidros e Alumínio</h1>
+            <p class="section-subtitle">
+                Guias práticos de escolha, instalação e manutenção, escritos por quem
+                instala vidro temperado na Zona Oeste todos os dias.
+            </p>
             <div class="row">
                 <!-- Blog Post 1 -->
                 <div class="col-lg-8 mx-auto">
                     <article class="blog-post">
-                        <h3>Como escolher o vidro temperado ideal para sua casa</h3>
+                        <h2>Como escolher o vidro temperado ideal para sua casa</h2>
                         <div class="date">19 de Março, 2024</div>
                         <img src="/img/portfolio/janela.jpg" alt="Vidro temperado para residências" class="img-fluid">
                         <p>O vidro temperado é uma excelente escolha para quem busca segurança e beleza em sua residência. Neste artigo, vamos explicar os diferentes tipos de vidros temperados e como escolher o ideal para cada ambiente...</p>
@@ -27,7 +38,7 @@ import Base from '../layouts/Base.astro';
                     </article>
 
                     <article class="blog-post">
-                        <h3>Manutenção e limpeza do box blindex: guia completo</h3>
+                        <h2>Manutenção e limpeza do box blindex: guia completo</h2>
                         <div class="date">18 de Março, 2024</div>
                         <img src="/img/portfolio/box.jpg" alt="Manutenção de box blindex" class="img-fluid">
                         <p>O box blindex é uma solução prática e elegante para o banheiro, mas requer cuidados específicos para manter sua beleza e durabilidade. Aprenda as melhores práticas de limpeza e manutenção...</p>
@@ -35,7 +46,7 @@ import Base from '../layouts/Base.astro';
                     </article>
 
                     <article class="blog-post">
-                        <h3>Cortinas de vidro: tendências e dicas de instalação</h3>
+                        <h2>Cortinas de vidro: tendências e dicas de instalação</h2>
                         <div class="date">17 de Março, 2024</div>
                         <img src="/img/portfolio/cortina.jpg" alt="Cortinas de vidro modernas" class="img-fluid">
                         <p>As cortinas de vidro são uma tendência em arquitetura moderna. Descubra as últimas tendências e aprenda como escolher e instalar a cortina de vidro perfeita para seu espaço...</p>

--- a/src/styles/index-inline.css
+++ b/src/styles/index-inline.css
@@ -39,6 +39,24 @@
             --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
             --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
             --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+
+            /* Altura do cabeçalho. Ele é `position: fixed`, então tudo o que também
+               se prende ao topo da viewport precisa começar exatamente onde ele
+               termina. Enquanto esse número vivia só na cabeça de quem escreveu o
+               CSS, a barra do sticky CTA nasceu com `top: 0` e o cabeçalho a cobriu
+               inteira. O token é honrado por `min-height` no .header logo abaixo,
+               então não é uma suposição: é a altura real. 80px é o que o conteúdo do
+               header já mede no desktop (o botão "Orçamento Grátis" tem min-height 48
+               mais 2x16 de padding do .navbar); no mobile o min-height completa. */
+            --header-height: 80px;
+
+            /* Área morta do botão flutuante do WhatsApp: diâmetro + folga da borda.
+               O botão é fixed, logo a página inteira desliza por baixo dele — sem
+               reservar essa faixa, texto e checkbox terminam embaixo de um alvo de
+               toque que está sempre por cima. */
+            --float-size: 60px;
+            --float-inset: 30px;
+            --float-safe-area: calc(var(--float-size) + var(--float-inset));
         }
 
         * {
@@ -59,6 +77,27 @@
             max-width: 1200px;
             margin: 0 auto;
             padding: 0 20px;
+        }
+
+        /* 1380px = 1200 do container + 2x a área do flutuante: acima disso a margem
+           lateral que sobra já é maior que o botão e o conteúdo nunca o alcança.
+           Abaixo, o container encosta na borda direita e precisa da folga — senão o
+           flutuante fica em cima do selo "Parcelamos em até 12x", do 3º depoimento e
+           dos checkboxes do formulário, que foi o que acontecia. */
+        @media (max-width: 1380px) {
+            .container {
+                /* A folga é medida da borda da viewport, e os 20px de padding já estão
+                   dentro dela — daí max() e não soma. */
+                padding-right: max(20px, var(--float-safe-area));
+            }
+
+            /* O cabeçalho está preso no topo e o flutuante no rodapé da viewport: eles
+               nunca se cruzam, então o header não paga a folga. Pagando, o menu não
+               cabia entre 769 e ~820px e o botão de orçamento quebrava em duas linhas
+               (header de 100px em vez de 80px). */
+            .header .container {
+                padding-right: 20px;
+            }
         }
 
         .section {
@@ -140,6 +179,9 @@
             box-shadow: var(--shadow);
             z-index: 1000;
             transition: var(--transition);
+            /* Garante que --header-height seja a altura de verdade, e não um palpite
+               que outro arquivo copia. */
+            min-height: var(--header-height);
         }
 
         .navbar {
@@ -282,6 +324,8 @@
             margin-top: 3rem;
         }
 
+        /* Sem `cursor: pointer`: o card não tem handler nenhum. Quem clica no meio dele
+           não acontece nada — o que é clicável é o botão "Pedir Orçamento" dentro. */
         .service-card {
             background: var(--white);
             border-radius: 12px;
@@ -289,7 +333,6 @@
             box-shadow: var(--shadow);
             transition: var(--transition);
             text-align: center;
-            cursor: pointer;
         }
 
         .service-card:hover {
@@ -520,10 +563,13 @@
             background: var(--white);
         }
 
+        /* O anel de foco sai do próprio --primary. Antes era rgba(30, 64, 175, .1),
+           que é o indigo do Tailwind da paleta v1 — a borda já tinha virado azul da
+           placa e o halo continuava do azul antigo. */
         .form-control:focus {
             outline: none;
             border-color: var(--primary);
-            box-shadow: 0 0 0 3px rgba(30, 64, 175, 0.1);
+            box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 12%, transparent);
         }
 
         .form-control.is-valid {
@@ -627,13 +673,14 @@
             animation: spin 0.6s linear infinite;
         }
 
-        /* WhatsApp Floating Button */
+        /* WhatsApp Floating Button — tamanho e posição vêm dos tokens porque a folga
+           reservada no .container é calculada a partir deles. */
         .whatsapp-float {
             position: fixed;
-            bottom: 30px;
-            right: 30px;
-            width: 60px;
-            height: 60px;
+            bottom: var(--float-inset);
+            right: var(--float-inset);
+            width: var(--float-size);
+            height: var(--float-size);
             background: #25d366;
             border-radius: 50%;
             display: flex;
@@ -791,12 +838,15 @@
                 grid-template-columns: 1fr;
             }
 
+            /* Menor e mais colado no canto: cada pixel aqui é pixel de folga que o
+               conteúdo tem que abrir mão no lado direito. */
+            :root {
+                --float-size: 52px;
+                --float-inset: 14px;
+            }
+
             .whatsapp-float {
-                bottom: 20px;
-                right: 20px;
-                width: 56px;
-                height: 56px;
-                font-size: 1.75rem;
+                font-size: 1.6rem;
             }
         }
 

--- a/src/styles/ui-improvements.css
+++ b/src/styles/ui-improvements.css
@@ -195,9 +195,12 @@
     transition: border-color 0.2s, box-shadow 0.2s;
 }
 
+/* Foco derivado de --primary. Esta regra carrega DEPOIS de index-inline.css, então
+   era ela que pintava o anel de foco de verde-água (#1abc9c, do tema Bootstrap que o
+   site abandonou) — mexer no anel de lá não mudava nada na tela. */
 .form-control:focus {
-    border-color: #1abc9c;
-    box-shadow: 0 0 0 0.2rem rgba(26, 188, 156, 0.15);
+    border-color: var(--primary);
+    box-shadow: 0 0 0 0.2rem color-mix(in srgb, var(--primary) 15%, transparent);
 }
 
 .form-control.is-valid {
@@ -369,9 +372,9 @@
    IMPROVED ACCESSIBILITY
    ============================================================================ */
 
-/* Better focus indicators */
+/* Better focus indicators — mesma cor da marca, pelo mesmo motivo do anel acima. */
 *:focus-visible {
-    outline: 2px solid #1abc9c;
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
@@ -379,7 +382,7 @@ button:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible {
-    outline: 2px solid #1abc9c;
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 
@@ -401,8 +404,8 @@ textarea:focus-visible {
 }
 
 .checkbox-item:focus-within {
-    background-color: #e7f9f5;
-    outline: 2px solid #1abc9c;
+    background-color: color-mix(in srgb, var(--primary) 8%, white);
+    outline: 2px solid var(--primary);
     outline-offset: 2px;
 }
 

--- a/src/styles/whatsapp-cta.css
+++ b/src/styles/whatsapp-cta.css
@@ -7,9 +7,13 @@
    STICKY CTA BAR (aparece após scroll)
    ============================================================================ */
 
+/* Começa onde o cabeçalho termina. Com `top: 0` a barra ficava ATRÁS do header
+   (fixed, z-index 1000, opaco): no desktop desaparecia inteira e no mobile sobrava
+   só o botão, sem a frase que justifica o clique. A altura vem do token definido
+   junto do .header, então não há um segundo número para desencontrar. */
 .whatsapp-sticky-cta {
     position: fixed;
-    top: 0;
+    top: var(--header-height);
     left: 0;
     right: 0;
     background: linear-gradient(135deg, #25D366 0%, #128C7E 100%);
@@ -17,11 +21,15 @@
     padding: 12px 20px;
     z-index: 999;
     transform: translateY(-100%);
-    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    /* Escondida também no visibility: só o transform deixaria a sombra verde
+       vazando por baixo do cabeçalho enquanto a barra está recolhida. */
+    visibility: hidden;
+    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), visibility 0.4s;
 }
 
 .whatsapp-sticky-cta.active {
     transform: translateY(0);
+    visibility: visible;
 }
 
 .sticky-cta-content {
@@ -70,34 +78,34 @@
     color: #128C7E;
 }
 
-.sticky-cta-button i {
+.sticky-cta-button .icon {
     font-size: 1.3rem;
 }
 
-/* Mobile */
+/* Mobile — barra em uma linha só. Empilhada (texto em duas linhas + botão de largura
+   total) ela tinha 126px de altura: mais de um sétimo da tela coberto por uma barra
+   que o visitante não pediu. Cortando a linha de apoio e mantendo o botão ao lado do
+   texto, sobra a promessa e o clique, que é o que a barra existe para oferecer. */
 @media (max-width: 768px) {
     .whatsapp-sticky-cta {
-        padding: 10px 15px;
+        padding: 8px 15px;
     }
-    
+
     .sticky-cta-content {
-        flex-direction: column;
-        text-align: center;
-        gap: 10px;
+        gap: 12px;
     }
-    
+
     .sticky-cta-text strong {
-        font-size: 0.95rem;
+        font-size: 0.875rem;
     }
-    
+
     .sticky-cta-text span {
-        font-size: 0.8rem;
+        display: none;
     }
-    
+
     .sticky-cta-button {
-        width: 100%;
-        justify-content: center;
-        padding: 12px 20px;
+        padding: 10px 16px;
+        font-size: 0.875rem;
     }
 }
 
@@ -128,7 +136,7 @@
     color: white;
 }
 
-.service-whatsapp-cta i {
+.service-whatsapp-cta .icon {
     font-size: 1.2rem;
 }
 
@@ -143,14 +151,11 @@
    FLOATING BUTTON ENHANCEMENTS
    ============================================================================ */
 
-/* Garantir que o botão flutuante mantenha position fixed */
+/* Tamanho e posição do flutuante vivem num lugar só (index-inline.css, com os
+   tokens --float-*). Aqui havia uma segunda cópia com !important brigando com a
+   primeira — e era ela que valia, então mexer na regra "de verdade" não fazia nada.
+   Só o empilhamento fica: o flutuante passa por cima da barra do sticky CTA. */
 .whatsapp-float {
-    position: fixed !important;
-    bottom: 30px !important;
-    right: 30px !important;
-    left: auto !important;
-    width: 64px;
-    height: 64px;
     z-index: 1000;
 }
 
@@ -313,21 +318,6 @@
    ============================================================================ */
 
 @media (max-width: 768px) {
-    /* Botão flutuante maior em mobile - manter fixed! */
-    .whatsapp-float {
-        position: fixed !important;
-        width: 68px !important;
-        height: 68px !important;
-        bottom: 20px !important;
-        right: 20px !important;
-        left: auto !important;
-        z-index: 1000 !important;
-    }
-    
-    .whatsapp-float i {
-        font-size: 2rem !important;
-    }
-    
     /* Tooltip não aparece em mobile */
     .whatsapp-float-tooltip {
         display: none;


### PR DESCRIPTION
Ten runtime defects, all reproduced in a browser against the built output before and after. Most of them come from the same root cause: the three scripts in `public/js` still inject markup for the stack the asset migration removed, and the CSS still carried numbers from before the header and the palette changed.

## What was wrong → evidence → fix

| # | Defect | Evidence (measured) | Fix |
|---|---|---|---|
| 1 | Sticky CTA bar invisible | Bar at `top: 0`, `z-index: 999`, under `.header` (`fixed`, `z-index: 1000`, 80px tall). Desktop: 100% hidden. Mobile: bar was 126px, only the button showed. | `--header-height` token defined next to `.header` and enforced by `min-height` there, so it is the real height, not a copy; bar uses `top: var(--header-height)`. Hides with `visibility` too, otherwise its green shadow leaked below the header while retracted. Mobile drops the supporting line and keeps one row: 126px → 63px. |
| 2 | 15 Font Awesome tags drawing nothing | `document.querySelectorAll('i.fab, i.fas, i.far').length === 15` on a page with the form: 7 WhatsApp (sticky bar + 6 service buttons) and 8 form-validation marks from `ui-improvements.js`. | The 7 WhatsApp icons clone the SVG the page already renders for the floating button (`icons.json` → `Icon.astro`), so the path has one source of truth and no copy lands in `public/`. The 8 state marks (toast, field validation, alert, toast close) become characters — their meaning is already carried by border colour, title and the field's own green/red. Submit button restores its server-rendered label instead of rebuilding it. |
| 3 | Every WhatsApp link rewritten to `web.whatsapp.com` on desktop | `getWhatsAppWebURL` rewrote all of them, including the hero's correct `wa.me`. Users without an active browser session landed on a QR screen. Two of the URLs were `web.whatsapp.com` **in `site.ts`**, server-rendered — removing the JS pass alone would not have fixed them. | `waLink()` always uses `wa.me`, which does the app/web/store detection itself. `getWhatsAppWebURL` and `updateExistingLinks` deleted; per-section messages still reach each CTA. `site.ts` no longer emits `web.whatsapp.com`; `whatsappWeb` → `whatsappFooter` (the suffix is now the click origin, not the destination platform). |
| 4 | Floating button covering content | It is `fixed`, so the whole page scrolls under it: it sat over the 12x badge, the 3rd testimonial and the form checkboxes. | Size and inset are tokens (`--float-size`, `--float-inset`, `--float-safe-area`); `.container` reserves exactly that much on the right while the viewport is narrow enough for content to reach the corner (≤1380px = 1200 + 2×90). Header exempt: it is pinned at the top, never crosses the button, and paying the gutter made the nav wrap to two lines between 769–820px. Mobile button 56→52px, inset 20→14px. The duplicate `!important` block fighting the base rule is gone. |
| 5 | `© 2024` in the footer | Hardcoded in `Footer.astro`. | `new Date().getFullYear()` at build time → `© 2026`. |
| 6 | Focus ring in the old palette | `index-inline.css` had `rgba(30, 64, 175, .1)` (v1 Tailwind indigo), but the **effective** rule was `#1abc9c` in `ui-improvements.css`, which loads last — the rendered ring was teal from the abandoned Bootstrap theme. | Both derive from `--primary` via `color-mix`. Same for the `:focus-visible` outlines and the checkbox `:focus-within` tint. Measured: `color(srgb 0.0588 0.3725 0.6196 / 0.15)` = `#0f5f9e` at 15%. |
| 7 | `cursor: pointer` on a non-clickable card | `.service-card` has no handler; only the injected button inside it is clickable. | Affordance removed. The card was **not** made clickable — that is a product decision. |
| 8 | "Telefone" showed the mobile number | `QuoteForm.astro` printed `(21) 98792-6578` under both labels, both hardcoded, while the real landline lives in `site.ts` and shows correctly in the footer. | Reads `CONTACT.mobileDisplay` / `CONTACT.landlineDisplay`. |
| 9 | `blog.html` had no `<h1>` | Runtime: `h1: []`. Posts opened at `<h3>`. | Real `<h1>`, posts demoted to `<h2>`. Also switched `page-section` (dead Bootstrap class) to `section` with a top padding from the header token — otherwise the new `<h1>` renders behind the fixed header. |
| 10 | 3 of 4 nav items walked the visitor off the neighbourhood pages | Nav emitted `/index.html#servicos` and `/index.html#diferenciais` even where those sections exist locally — they just had no `id`. | Sections got `id="servicos"` / `id="diferenciais"`; `Nav.astro` gains `hasServices` / `hasDifferentials` following the existing `hasForm` pattern, and one `anchor(id, isLocal)` helper decides local vs. jump. Depoimentos keeps the `/index.html` fallback because that section only exists on the home. Every anchor emitted exists in the DOM. |

## How it was verified

`npm run build` (contrast gate + astro build) passes; the CI anchor/asset/key-file script was run against `dist` and passes. Everything below was measured in Chromium 141 against `npm run preview`, at 1440×900 and 390×844.

- **Sticky bar after 45% scroll** — desktop `top: 80, bottom: 156.5`, header bottom `80`, **overlap 0**, `fullyInViewport: true`, copy `"🎉 Orçamento Grátis em 2 Horas!"` topmost at its centre point. Mobile `top: 80, bottom: 142.8` (height 62.8 vs 126 before), overlap 0.
- **Header height sweep** at 360/390/480/600/768/769/900/1024/1280/1440/1920 → header is 80px at every width and the token is 80 (`token >= real` everywhere; the 769px case was 100.03 in an earlier iteration and is what surfaced the header-exempt rule).
- **Font Awesome** — `i.fab, i.fas, i.far, i[class*="fa-"]` = **0** on index, blog and realengo, on both viewports, including after firing `ToastManager.success/error` and `showAlert` (3 toasts rendered, `faInToasts: 0`, toast icons `["✓","✕","✕"]`). Sticky bar and all 6 service buttons render a real `<svg>` (19–21px box).
- **WhatsApp links** — 10 links on index, `web.whatsapp.com: 0`, `api.whatsapp.com: 0`, `wa.me: 10`. Realengo: 0 `web.whatsapp.com`.
- **Floating button** — scanned the full page height in half-viewport steps, sampling 5 points inside the button on each step, and collected any text-bearing or interactive element under it: **0 hits** on both viewports. The three reported spots checked by rectangle intersection: `badge12x`, `testimonial3`, `lastCheckbox` → `intersectsFloat: false` in both. Mobile content container `padding-right: 66px`, header container `20px`.
- **Focus ring** — `#name` focused (`matchesFocus: true`): `box-shadow: color(srgb 0.0588 0.3725 0.6196 / 0.15) 0 0 0 3.2px`, `border-color: rgb(15, 95, 158)`. `CSS.supports('color-mix(...)')` true; if it were not, the border colour and the `:focus-visible` outline still carry the state.
- **`.service-card` cursor** — computed `auto`.
- **Quote form** — `[{WhatsApp: "(21) 98792-6578"}, {Telefone: "(21) 3421-6066"}]`. Footer: `© 2026`.
- **blog.html** — `h1Count: 1`, text "Dicas sobre Vidros e Alumínio", internal order `H1 → H2 → H2 → H2`, h1 below the header on both viewports.
- **realengo.html** — nav resolves to `#servicos` (target exists), `#diferenciais` (exists), `/index.html#depoimentos` (fallback by design), `#contato` (exists); quote button `#contato`. Clicking "Serviços" stays on `/realengo.html` and lands the section at `top: 80`, flush with the header.

## Not in this PR

`ADS_CONVERSION_LABEL` is still empty on purpose — that value comes from the Google Ads console. Untouched by design: H1 copy, hero photo, trust badges, testimonials, `aggregateRating`, form position, service icons. `index.astro` and `LocalBusinessSchema.astro` are not modified at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
