### PR TITLE
feat: put the proof and the decision in the first screen, cut the scroll

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -54,7 +54,28 @@ const quoteHref = anchor('contato', hasForm);
       </a>
     </li>
   </ul>
-  <button class="mobile-menu-btn" aria-label="Abrir menu">
+  <button class="mobile-menu-btn" aria-label="Abrir menu" aria-expanded="false">
     <Icon name="bars" />
   </button>
 </nav>
+
+{/* Espelha no botão o estado do menu. Quem alterna o menu é o app.js, mexendo no
+    style do <ul> — então aqui a gente OBSERVA em vez de registrar um segundo
+    handler de clique, que se anularia com o primeiro. Sem isto o botão fica em 3
+    barras com o menu aberto e o leitor de tela não sabe que abriu. */}
+<script is:inline>
+  (() => {
+    const btn = document.querySelector('.mobile-menu-btn');
+    const menu = document.querySelector('.nav-menu');
+    if (!btn || !menu) return;
+    const sync = () => {
+      const usable = getComputedStyle(btn).display !== 'none';
+      const open = usable && getComputedStyle(menu).display !== 'none';
+      btn.setAttribute('aria-expanded', String(open));
+      btn.setAttribute('aria-label', open ? 'Fechar menu' : 'Abrir menu');
+    };
+    new MutationObserver(sync).observe(menu, { attributes: true, attributeFilter: ['style', 'class'] });
+    window.addEventListener('resize', sync);
+    sync();
+  })();
+</script>

--- a/src/components/QuoteForm.astro
+++ b/src/components/QuoteForm.astro
@@ -207,7 +207,9 @@ const {
                             <div class="form-help">Quanto mais detalhes, melhor será nosso orçamento</div>
                         </div>
 
-                        <button type="submit" class="btn btn-primary" id="submitBtn" style="width: 100%;">
+                        {/* Cor de CTA, não azul de marca: o botão que fecha a conversão é o
+                            único que precisava do âmbar e era o único que não usava. */}
+                        <button type="submit" class="btn btn-success" id="submitBtn" style="width: 100%;">
                             <span id="btnText">
                                 <Icon name="paper-plane" /> Solicitar Orçamento Grátis
                             </span>
@@ -215,6 +217,11 @@ const {
 
                         <p style="text-align: center; margin-top: 1rem; font-size: 0.875rem; color: var(--gray);">
                             <Icon name="clock" /> Responderemos em até 2 horas úteis
+                        </p>
+
+                        <p class="form-privacy">
+                            <Icon name="shield-alt" /> Usamos seu nome, telefone e bairro apenas para
+                            responder este pedido de orçamento.
                         </p>
                     </form>
                 </div>

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -13,6 +13,8 @@ export const CONTACT = {
   landline: '+552134216066',
   landlineDisplay: '(21) 3421-6066',
   email: 'contato@verlyvidracaria.com',
+  /** Mesmo horário que o rodapé e o LocalBusiness já publicam — 8h às 18h, Seg-Sáb. */
+  hoursDisplay: 'Seg a Sáb, 8h às 18h',
   // Todo link de WhatsApp passa por wa.me. É ele que escolhe entre o app instalado,
   // o WhatsApp Web e a loja de aplicativos; apontar direto para web.whatsapp.com/send
   // manda quem não tem sessão ativa no navegador para uma tela de QR code, o que

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -54,8 +54,13 @@ const faqSchema =
         <div class="hero-badge">
           <Icon name="map-marker-alt" /> Atendemos {n.name} e toda a Zona Oeste
         </div>
-        {/* palavra-chave primeiro, métrica depois — o index já usa essa fórmula */}
-        <h1>{n.h1} — Orçamento em até 2 Horas</h1>
+        {/* palavra-chave primeiro, métrica depois — o index já usa essa fórmula.
+            O travessão era um separador que só o olho enxergava: em blocos, a
+            métrica ganha o peso visual e o h1 fecha em duas linhas. */}
+        <h1 class="hero-h1">
+          <span class="hero-h1-lead">{n.h1}</span>
+          <span class="hero-h1-metric">Orçamento em até 2 Horas</span>
+        </h1>
         {n.heroSubtitle && <p class="hero-subtitle">{n.heroSubtitle}</p>}
         <div class="hero-cta">
           <a href="#contato" class="btn btn-success btn-lg">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import { Image } from 'astro:assets';
 import Base from '../layouts/Base.astro';
 import lojaFrente from '../assets/loja-verly-realengo.png';
 import QuoteForm from '../components/QuoteForm.astro';
+import { CONTACT } from '../data/site';
 ---
 
 <Base
@@ -27,7 +28,14 @@ import QuoteForm from '../components/QuoteForm.astro';
                 <div class="hero-badge">
                     <Icon name="map-marker-alt" /> Atendemos toda Zona Oeste RJ
                 </div>
-                <h1>Vidraçaria na Zona Oeste<br>Orçamento em até 2 Horas</h1>
+                {/* Promessa e métrica em blocos separados, não um <br> no meio de uma
+                    linha de 3.5rem: naquele tamanho "Vidraçaria na Zona Oeste" já
+                    quebrava sozinha e o <br> somava a QUARTA linha. As páginas de
+                    bairro usam a mesma estrutura. */}
+                <h1 class="hero-h1">
+                    <span class="hero-h1-lead">Vidraçaria na Zona Oeste</span>
+                    <span class="hero-h1-metric">Orçamento em até 2 Horas</span>
+                </h1>
                 <p class="hero-subtitle">
                     Especialistas em Box para Banheiro, Sacadas Envidraçadas, Guarda-corpos e mais. 
                     Atendimento rápido, qualidade garantida e instalação profissional.
@@ -140,6 +148,28 @@ import QuoteForm from '../components/QuoteForm.astro';
         </div>
     </section>
 
+    <!-- Ponto de conversão no meio da página. As páginas de bairro já trazem o
+         formulário exatamente aqui, logo depois dos serviços: é onde o visitante
+         acabou de reconhecer o que precisa (interesse) e ainda faltam ~5.000px de
+         rolagem no celular até o formulário. Faixa com âncora, não um segundo
+         <QuoteForm /> — ver o comentário de .cta-band no CSS. -->
+    <section class="cta-band">
+        <div class="container cta-band-inner">
+            <div>
+                <h2>Achou o serviço que precisa?</h2>
+                <p>Orçamento gratuito, sem compromisso, com resposta em até 2 horas úteis.</p>
+            </div>
+            <div class="cta-band-actions">
+                <a href="#contato" class="btn btn-success">
+                    <Icon name="clipboard-check" /> Solicitar Orçamento Grátis
+                </a>
+                <a href={CONTACT.whatsappDirect} target="_blank" rel="noopener" class="cta-band-alt">
+                    ou fale direto no WhatsApp
+                </a>
+            </div>
+        </div>
+    </section>
+
     <!-- Why Choose Us -->
     <section id="diferenciais" class="section why-choose">
         <div class="container">
@@ -153,7 +183,7 @@ import QuoteForm from '../components/QuoteForm.astro';
                         <Icon name="rocket" />
                     </div>
                     <div class="feature-content">
-                        <h4>Atendimento Local Rápido</h4>
+                        <h3>Atendimento Local Rápido</h3>
                         <p>Estamos na Zona Oeste. Orçamento em até 2 horas e atendimento no mesmo dia quando possível.</p>
                     </div>
                 </div>
@@ -162,7 +192,7 @@ import QuoteForm from '../components/QuoteForm.astro';
                         <Icon name="user-tie" />
                     </div>
                     <div class="feature-content">
-                        <h4>Equipe Especializada</h4>
+                        <h3>Equipe Especializada</h3>
                         <p>Profissionais experientes e certificados para instalações seguras e de qualidade.</p>
                     </div>
                 </div>
@@ -171,7 +201,7 @@ import QuoteForm from '../components/QuoteForm.astro';
                         <Icon name="certificate" />
                     </div>
                     <div class="feature-content">
-                        <h4>Garantia Total</h4>
+                        <h3>Garantia Total</h3>
                         <p>Todos os nossos serviços possuem garantia. Trabalhamos apenas com materiais de primeira.</p>
                     </div>
                 </div>
@@ -180,7 +210,7 @@ import QuoteForm from '../components/QuoteForm.astro';
                         <Icon name="dollar-sign" />
                     </div>
                     <div class="feature-content">
-                        <h4>Orçamento Gratuito</h4>
+                        <h3>Orçamento Gratuito</h3>
                         <p>Fazemos orçamento sem compromisso. Medição e consultoria incluídas.</p>
                     </div>
                 </div>
@@ -189,7 +219,7 @@ import QuoteForm from '../components/QuoteForm.astro';
                         <Icon name="map-marked-alt" />
                     </div>
                     <div class="feature-content">
-                        <h4>Cobertura Completa</h4>
+                        <h3>Cobertura Completa</h3>
                         <p>Atendemos Barra, Recreio, Jacarepaguá, Campo Grande, Realengo e toda Zona Oeste.</p>
                     </div>
                 </div>
@@ -198,7 +228,7 @@ import QuoteForm from '../components/QuoteForm.astro';
                         <Icon name="crown" />
                     </div>
                     <div class="feature-content">
-                        <h4>Materiais Premium</h4>
+                        <h3>Materiais Premium</h3>
                         <p>Vidros temperados de alta qualidade e perfis de alumínio com acabamento superior.</p>
                     </div>
                 </div>
@@ -224,7 +254,7 @@ import QuoteForm from '../components/QuoteForm.astro';
                         <div class="testimonial-author">
                             <div class="testimonial-avatar">MC</div>
                             <div class="testimonial-info">
-                                <h5>Mariana Costa</h5>
+                                <h3>Mariana Costa</h3>
                                 <p>Barra da Tijuca</p>
                                 <div class="testimonial-stars">★★★★★</div>
                             </div>
@@ -241,7 +271,7 @@ import QuoteForm from '../components/QuoteForm.astro';
                         <div class="testimonial-author">
                             <div class="testimonial-avatar">RS</div>
                             <div class="testimonial-info">
-                                <h5>Ricardo Santos</h5>
+                                <h3>Ricardo Santos</h3>
                                 <p>Recreio dos Bandeirantes</p>
                                 <div class="testimonial-stars">★★★★★</div>
                             </div>
@@ -258,7 +288,7 @@ import QuoteForm from '../components/QuoteForm.astro';
                         <div class="testimonial-author">
                             <div class="testimonial-avatar">PL</div>
                             <div class="testimonial-info">
-                                <h5>Paula Lima</h5>
+                                <h3>Paula Lima</h3>
                                 <p>Jacarepaguá</p>
                                 <div class="testimonial-stars">★★★★★</div>
                             </div>

--- a/src/pages/obrigado.astro
+++ b/src/pages/obrigado.astro
@@ -1,5 +1,7 @@
 ---
+import Icon from '../components/Icon.astro';
 import Base from '../layouts/Base.astro';
+import { CONTACT } from '../data/site';
 ---
 
 <Base
@@ -10,12 +12,31 @@ import Base from '../layouts/Base.astro';
 >
 
     <!-- Navigation -->
-    
+
     <div style="height: 80px;"></div>
   <div class="thanks-box">
     <h1>Obrigado!</h1>
-    <p>Recebemos seu pedido de orçamento.<br>
-    Em breve nossa equipe entrará em contato.</p>
-    <a href="/" class="btn btn-primary btn-home">Voltar para o site</a>
+    <p>
+      Recebemos seu pedido de orçamento. Respondemos em até <strong>2 horas úteis</strong>.
+      Atendemos {CONTACT.hoursDisplay}.
+    </p>
+    {/* A página era um beco sem saída: só "voltar para o site", que é justamente o
+        que quem acabou de enviar o formulário não precisa. Abrir a conversa no
+        WhatsApp resolve o outro lado — quando a Verly ligar ou escrever, o número
+        já está no celular de quem pediu. */}
+    <a
+      href={CONTACT.whatsappDirect}
+      class="btn btn-success thanks-next"
+      target="_blank"
+      rel="noopener"
+      data-context="thank-you-page"
+    >
+      <Icon name="whatsapp" /> Adiantar pelo WhatsApp
+    </a>
+    <p class="thanks-meta">
+      Nosso número é <a href={`tel:+${CONTACT.mobile}`}>{CONTACT.mobileDisplay}</a> — salve
+      para reconhecer nosso contato.
+    </p>
+    <a href="/" class="thanks-back">Voltar para o site</a>
   </div>
 </Base>

--- a/src/styles/index-inline.css
+++ b/src/styles/index-inline.css
@@ -169,6 +169,12 @@
             box-shadow: var(--shadow-lg);
         }
 
+        /* O spinner do submit era branco (herdado de ui-improvements.css) e sumia no
+           âmbar. Com o botão de envio agora na cor de CTA, ele acompanha o texto. */
+        #submitBtn.btn-loading::after {
+            border-top-color: var(--cta-text);
+        }
+
         /* Header/Navigation */
         .header {
             position: fixed;
@@ -269,16 +275,39 @@
         }
 
         .hero h1 {
-            font-size: 3.5rem;
+            font-size: 3rem;
             font-weight: 800;
-            line-height: 1.2;
-            margin-bottom: 1.5rem;
+            line-height: 1.15;
+            margin-bottom: 1.25rem;
             animation: fadeInUp 0.6s ease-out 0.2s both;
+        }
+
+        /* Manchete em dois blocos. A quebra é estrutural em vez de um <br>, e os dois
+           pedaços deixam de ler como frase corrida: primeiro o que somos e onde,
+           depois a métrica — que é o que faz clicar, então leva o corpo grande. */
+        .hero-h1 {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+            text-wrap: balance;
+        }
+
+        .hero-h1-lead {
+            font-size: 1.5rem;
+            font-weight: 700;
+            line-height: 1.25;
+            letter-spacing: 0.005em;
+        }
+
+        /* Corpo grande fecha melhor apertado — e ganha alguns pixels de largura, que
+           é o que mantém a métrica numa linha só. */
+        .hero-h1-metric {
+            letter-spacing: -0.015em;
         }
 
         .hero-subtitle {
             font-size: 1.25rem;
-            margin-bottom: 2.5rem;
+            margin-bottom: 2rem;
             opacity: 0.95;
             animation: fadeInUp 0.6s ease-out 0.4s both;
         }
@@ -287,41 +316,75 @@
             display: flex;
             gap: 1rem;
             justify-content: center;
+            align-items: center;
             flex-wrap: wrap;
             animation: fadeInUp 0.6s ease-out 0.6s both;
         }
 
+        /* Hierarquia entre os dois CTAs. Antes eram do mesmo tamanho, lado a lado:
+           quem chega tem que ESCOLHER antes de saber o que quer. Agora o âmbar é
+           inequivocamente o primário e o WhatsApp fica como alternativa — mesmo
+           link, mesma cor de marca, menos peso. */
+        .hero-cta .btn-success {
+            font-size: 1.125rem;
+            padding: 18px 36px;
+            box-shadow: var(--shadow-lg);
+        }
+
+        .hero-cta .btn-whatsapp {
+            font-size: 0.9375rem;
+            padding: 12px 20px;
+            min-height: 44px;
+        }
+
         .trust-badges {
-            display: flex;
-            gap: 2rem;
+            /* grid-auto-flow: column põe todos os selos numa linha só, seja lá quantos
+               forem — a home tem 5, as páginas de bairro 4. Com flex-wrap sobrava
+               órfão na segunda linha e, na home, o selo de avaliação (o de maior peso)
+               caía abaixo da dobra. */
+            display: grid;
+            grid-auto-flow: column;
+            grid-auto-columns: minmax(0, 1fr);
+            gap: 0.875rem;
             justify-content: center;
-            margin-top: 3rem;
-            flex-wrap: wrap;
+            margin-top: 2rem;
             animation: fadeInUp 0.6s ease-out 0.8s both;
         }
 
         .trust-badge {
             display: flex;
-            flex-direction: column;
             align-items: center;
             gap: 0.5rem;
+            text-align: left;
+        }
+
+        /* A avaliação é a prova social mais forte da dobra, então entra primeiro.
+           Só a ordem visual muda: o texto e o DOM ficam como estão. */
+        .trust-badges > :nth-child(5) {
+            order: -1;
         }
 
         .trust-badge-icon {
-            font-size: 2rem;
+            font-size: 1.25rem;
+            line-height: 1;
+            flex-shrink: 0;
         }
 
         .trust-badge-text {
             font-size: 0.875rem;
             font-weight: 500;
+            line-height: 1.3;
         }
 
         /* Services Section */
+        /* Colunas explícitas por breakpoint em vez de auto-fit. Com minmax(280px) o
+           1440 dava 4 colunas para 6 cartões — 4+2, e o vazio à direita do tamanho de
+           dois cartões. 3 colunas fecham as duas linhas; ver o bloco de grades abaixo. */
         .services-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            grid-template-columns: minmax(0, 1fr);
             gap: 2rem;
-            margin-top: 3rem;
+            margin-top: 2.5rem;
         }
 
         /* Sem `cursor: pointer`: o card não tem handler nenhum. Quem clica no meio dele
@@ -372,9 +435,9 @@
 
         .features-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            grid-template-columns: minmax(0, 1fr);
             gap: 2rem;
-            margin-top: 3rem;
+            margin-top: 2.5rem;
         }
 
         .feature-item {
@@ -396,7 +459,10 @@
             flex-shrink: 0;
         }
 
-        .feature-content h4 {
+        /* h3 e não h4: os diferenciais são filhos diretos do h2 da seção, e o salto
+           H2→H4 era um dos dois que sobravam na home. O corpo é o mesmo de antes: aqui
+           muda a hierarquia, não a aparência. */
+        .feature-content h3 {
             font-size: 1.125rem;
             font-weight: 700;
             margin-bottom: 0.5rem;
@@ -411,9 +477,9 @@
         /* Testimonials Section */
         .testimonials-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            grid-template-columns: minmax(0, 1fr);
             gap: 2rem;
-            margin-top: 3rem;
+            margin-top: 2.5rem;
         }
 
         .testimonial-card {
@@ -465,7 +531,11 @@
             font-size: 1.25rem;
         }
 
-        .testimonial-info h5 {
+        /* h3 e não h5: o nome do cliente é filho direto do h2 da seção. O corpo agora é
+           explícito — com a tag antiga ele saía do default do <h5>, 13.3px, menor que a
+           própria legenda do bairro abaixo dele. */
+        .testimonial-info h3 {
+            font-size: 1rem;
             font-weight: 600;
             color: var(--dark);
         }
@@ -708,11 +778,21 @@
             padding: 3rem 0 1.5rem;
         }
 
+        /* Colunas explícitas: com auto-fit os 4 blocos do rodapé viravam 3+1 em 1024,
+           mesmo buraco das outras grades. */
         .footer-content {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            grid-template-columns: minmax(0, 1fr);
             gap: 3rem;
             margin-bottom: 2rem;
+        }
+
+        @media (min-width: 481px) {
+            .footer-content { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        }
+
+        @media (min-width: 1200px) {
+            .footer-content { grid-template-columns: repeat(4, minmax(0, 1fr)); }
         }
 
         .footer-section h2 {
@@ -795,24 +875,191 @@
                 display: block;
             }
 
+            /* O header é fixed: o hero começa onde ele termina, mais uma folga pequena.
+               Cada pixel aqui empurra a foto e os selos para fora da primeira tela. */
             .hero {
-                padding: 120px 0 60px;
+                padding: calc(var(--header-height) + 8px) 0 32px;
             }
 
             .hero h1 {
-                font-size: 2.5rem;
+                font-size: 2.25rem;
+            }
+
+            .hero-h1-lead {
+                font-size: 1.25rem;
             }
 
             .hero-subtitle {
                 font-size: 1.125rem;
+                margin-bottom: 1.25rem;
             }
 
+            /* Ritmo vertical do celular. Com 80px de padding e um cartão por tela a home
+               tinha 10.449px de rolagem — 12 telas até o formulário. Aqui aperta-se o
+               ritmo; a densidade dos cartões vem nos blocos seguintes. */
             .section {
-                padding: 60px 0;
+                padding: 32px 0;
             }
 
             .section-title {
-                font-size: 2rem;
+                font-size: 1.625rem;
+                margin-bottom: 0.625rem;
+            }
+
+            .section-subtitle {
+                margin-bottom: 1rem;
+            }
+
+            .services-grid,
+            .features-grid,
+            .testimonials-grid {
+                margin-top: 1.25rem;
+                gap: 0.75rem;
+            }
+
+            /* Cartão de serviço deitado: o ícone de 80px empilhado sobre o texto gastava
+               uma tela inteira por cartão. Deitado cabem dois por tela, e nada sai —
+               mesmo ícone, mesmo título, mesma descrição. Grade em vez de flex porque o
+               cartão não tem wrapper de texto, e porque o whatsapp-cta.js anexa um <a>
+               nele em tempo de execução: qualquer filho novo cai na coluna do texto. */
+            .services-grid .service-card {
+                display: grid;
+                grid-template-columns: 44px minmax(0, 1fr);
+                column-gap: 0.75rem;
+                align-content: start;
+                text-align: left;
+                padding: 0.875rem 1rem;
+            }
+
+            .services-grid .service-card > * {
+                grid-column: 2;
+            }
+
+            .services-grid .service-card > .service-icon {
+                grid-column: 1;
+                grid-row: 1 / span 3; /* atravessa título, descrição e o CTA injetado */
+                width: 44px;
+                height: 44px;
+                font-size: 1.25rem;
+                margin: 0;
+            }
+
+            .services-grid .service-whatsapp-cta {
+                margin-top: 0.5rem;
+            }
+
+            .service-card h3 {
+                font-size: 1.125rem;
+                margin-bottom: 0.25rem;
+            }
+
+            .service-card p {
+                line-height: 1.5;
+            }
+
+            .features-grid {
+                gap: 0.75rem;
+            }
+
+            .feature-icon {
+                width: 40px;
+                height: 40px;
+                font-size: 1.125rem;
+            }
+
+            .testimonial-card {
+                padding: 0.875rem 1rem;
+            }
+
+            .testimonial-text {
+                line-height: 1.5;
+                margin-bottom: 0.75rem;
+            }
+
+            .testimonial-quote {
+                top: 0.25rem;
+            }
+
+            .testimonial-content {
+                margin-top: 0.25rem;
+            }
+
+            .testimonial-avatar {
+                width: 44px;
+                height: 44px;
+                font-size: 1.125rem;
+            }
+
+            .contact-info h3 {
+                font-size: 1.375rem;
+                margin-bottom: 1rem;
+            }
+
+            .contact-item {
+                margin-bottom: 0.75rem;
+            }
+
+            .contact-item-icon {
+                width: 36px;
+                height: 36px;
+            }
+
+            textarea.form-control {
+                min-height: 76px;
+            }
+
+            .footer-section h2 {
+                margin-bottom: 0.5rem;
+            }
+
+            .footer-section li {
+                margin-bottom: 0.25rem;
+            }
+
+            /* As duas listas do rodapé (serviços e bairros) têm 6 itens curtos cada e
+               ocupavam 12 linhas empilhadas depois do formulário. Em duas colunas são 6,
+               sem cortar link nenhum. */
+            .footer-section ul {
+                column-count: 2;
+                column-gap: 1rem;
+            }
+
+            .contact-form .form-group {
+                margin-bottom: 0.875rem;
+            }
+
+            /* A linha inteira do checkbox vira alvo de toque. Antes só o quadradinho e o
+               rótulo respondiam, e o input herdava min-height 44px de ui-improvements
+               esticando cada linha para ~72px: oito serviços comiam duas telas. */
+            .checkbox-group .checkbox-item {
+                padding: 0 0.5rem;
+                gap: 0.625rem;
+                min-height: 44px;
+            }
+
+            .checkbox-group .checkbox-item label {
+                flex: 1;
+                display: flex;
+                align-items: center;
+                min-height: 44px;
+                margin: 0;
+            }
+
+            .checkbox-group .checkbox-item input[type="checkbox"] {
+                min-height: 20px;
+            }
+
+            .footer {
+                padding: 1.75rem 0 1rem;
+            }
+
+            .footer-bottom {
+                padding-top: 1rem;
+            }
+
+            .footer-content {
+                gap: 1rem;
+                margin-bottom: 1rem;
             }
 
             .contact-wrapper {
@@ -824,18 +1071,59 @@
             /* Formulário aparece primeiro no mobile */
             .contact-info {
                 order: 2;
-                margin-top: 2rem;
-                padding: 2rem;
+                margin-top: 1.25rem;
+                padding: 1rem;
             }
 
             /* Formulário tem prioridade visual no mobile */
             .contact-form {
                 order: 1;
-                padding: 2rem;
+                padding: 1.25rem;
             }
 
+            /* Oito serviços em duas colunas onde o rótulo caiba inteiro: em coluna única
+               o grupo sozinho tomava uma tela e meia, mas abaixo de 420px sobram ~78px
+               de texto e "Janelas de Alumínio" quebra em três linhas. O alvo de toque
+               continua sendo a linha inteira. */
             .checkbox-group {
-                grid-template-columns: 1fr;
+                grid-template-columns: minmax(0, 1fr);
+            }
+
+            @media (min-width: 420px) {
+                .checkbox-group { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+            }
+
+            /* Menu aberto: o gap de 2rem é do desktop e, empilhado, dava um painel de
+               ~620px que cobria o H1. Cada item continua com 44px de alvo de toque. */
+            .nav-menu {
+                gap: 0.125rem;
+            }
+
+            .nav-menu li {
+                width: 100%;
+            }
+
+            .nav-menu .nav-link {
+                display: block;
+                padding: 0.6875rem 0.25rem;
+            }
+
+            .nav-menu .btn {
+                width: 100%;
+                margin-top: 0.375rem;
+            }
+
+            /* O botão não mudava de estado: seguia em 3 barras com o menu aberto, sem
+               afordância de fechar. O toggle é do app.js; aqui só o reflexo visual do
+               aria-expanded (ver o script no Nav.astro). */
+            .mobile-menu-btn[aria-expanded="true"] .icon {
+                display: none;
+            }
+
+            .mobile-menu-btn[aria-expanded="true"]::before {
+                content: '\00d7';
+                font-size: 1.875rem;
+                line-height: 1;
             }
 
             /* Menor e mais colado no canto: cada pixel aqui é pixel de folga que o
@@ -852,7 +1140,29 @@
 
         @media (max-width: 480px) {
             .hero h1 {
-                font-size: 2rem;
+                font-size: 1.875rem;
+            }
+
+            /* 16px, o piso de corpo de texto. Em aparelhos de 360px as duas linhas que
+               isso economiza são a diferença entre os 5 selos caberem na dobra ou não. */
+            .hero-subtitle {
+                font-size: 1rem;
+            }
+
+            /* Rótulo de selo é micro-texto, não corpo: 13px mantém cada um em uma linha
+               na coluna estreita ao lado da foto. */
+            .trust-badge-text {
+                font-size: 0.8125rem;
+            }
+
+            /* O rótulo do primário quebrava em duas linhas com 18px. */
+            .hero-cta .btn-success {
+                font-size: 1.0625rem;
+                padding: 16px 24px;
+            }
+
+            .hero-h1-lead {
+                font-size: 1.0625rem;
             }
 
             .btn {
@@ -860,13 +1170,12 @@
                 padding: 14px 24px;
             }
 
-            .trust-badges {
-                gap: 1rem;
+            /* O primário ocupa a largura toda; o WhatsApp, não. Dois botões full-width
+               empilhados voltavam a pesar igual. */
+            .hero-cta .btn-whatsapp {
+                width: auto;
             }
 
-            .trust-badge {
-                flex: 1 1 calc(50% - 0.5rem);
-            }
         }
 
 /* FAQ nativo (<details>/<summary>) — substitui o accordion do Bootstrap, que saiu
@@ -961,8 +1270,9 @@
 }
 
 /* Hero em duas colunas a partir de 1024px: texto à esquerda, foto à direita.
-   Abaixo disso volta a coluna única e a foto vem depois dos selos — no celular
-   o CTA tem que aparecer antes da imagem, não depois dela. */
+   Abaixo disso volta a coluna única, e a foto sobe para o lado dos selos — no
+   celular o CTA continua aparecendo ANTES da imagem, mas a imagem passou a caber
+   na primeira tela: a prova visual não pode ficar a 1.000px de rolagem. */
 .hero-grid {
     position: relative;
     z-index: 1;
@@ -978,6 +1288,68 @@
     border-radius: 14px;
     box-shadow: var(--shadow-xl);
 }
+/* Abaixo de 1024px: foto e selos dividem a mesma faixa, logo depois dos CTAs.
+   display: contents dissolve .hero-content para que os selos (que estão dentro
+   dele) e a foto (que é irmã dele) possam ficar lado a lado sem duplicar markup
+   nem mover a foto no DOM — no desktop ela precisa continuar sendo a 2ª coluna.
+   Empilhados, foto (467px) + selos não cabiam na primeira tela junto com os CTAs;
+   lado a lado ocupam a altura de um só. */
+@media (max-width: 1023px) {
+    .hero-content { display: contents; }
+    .hero-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 46%) minmax(0, 1fr);
+        column-gap: 0.875rem;
+        align-items: start;
+    }
+    .hero-badge,
+    .hero-h1,
+    .hero-subtitle,
+    .hero-cta {
+        grid-column: 1 / -1;
+    }
+    .hero-badge { justify-self: center; }
+    .hero-photo {
+        grid-column: 1;
+        margin: 1.25rem 0 0;
+        max-width: none;
+    }
+    /* Abaixo de 480px a foto cede um pouco de largura para os selos caberem em uma
+       linha cada: num aparelho de 360px o quinto selo saía da dobra por 15px. */
+    @media (max-width: 480px) {
+        .hero-grid { grid-template-columns: minmax(0, 42%) minmax(0, 1fr); }
+    }
+    .trust-badges {
+        grid-column: 2;
+        /* order manda os selos para DEPOIS da foto na ordem de posicionamento: eles
+           vêm antes no DOM (estão dentro do .hero-content) e, sem isto, o
+           auto-placement joga a foto para a linha seguinte em vez de ao lado. */
+        order: 1;
+        grid-auto-flow: row;
+        grid-template-columns: minmax(0, 1fr);
+        gap: 0.5rem;
+        margin-top: 1.25rem;
+        justify-content: stretch;
+    }
+}
+
+/* Abaixo de 1380px o .container reserva a faixa do botão flutuante e a coluna de
+   texto do hero cai de 672px para 582px, depois 406px em 1024. Com corpo fixo a
+   métrica voltava a quebrar em duas linhas; fluido ela fecha em uma em toda a
+   faixa. O medido: a métrica pede ~12.9px de largura por px de corpo. */
+@media (min-width: 1024px) and (max-width: 1380px) {
+    .hero h1 { font-size: clamp(1.875rem, 3vw, 2.8125rem); }
+    .hero-h1-lead { font-size: 1.25rem; }
+    /* Nessa faixa cada selo tem ~105px ou menos: com o ícone ao lado, o rótulo
+       encostava no selo vizinho. Ícone em cima devolve a largura inteira ao texto,
+       e os 5 continuam numa linha. */
+    .trust-badge {
+        flex-direction: column;
+        text-align: center;
+        gap: 0.25rem;
+    }
+}
+
 @media (min-width: 1024px) {
     .hero-grid {
         display: grid;
@@ -997,4 +1369,132 @@
         justify-content: flex-start;
     }
     .hero-photo { margin: 0; max-width: none; }
+}
+
+/* Grades fechando em linhas cheias. auto-fit escolhia o número de colunas pela
+   largura e ignorava quantos itens existem: 6 cartões em 4 colunas = 4+2. Os
+   números abaixo dividem 6 exatamente em cada breakpoint. */
+@media (min-width: 1024px) {
+    .services-grid,
+    .features-grid,
+    .testimonials-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+    /* 5 é primo: em 3 colunas sobra 3+2. A lista de razões das páginas de bairro tem
+       5 itens de uma linha, então lá as colunas viram 5. */
+    .services-grid:has(> :nth-child(5):last-child) {
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        gap: 1.25rem;
+    }
+}
+
+@media (min-width: 769px) and (max-width: 1023px) {
+    .services-grid,
+    .features-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .services-grid:has(> :nth-child(5):last-child) {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+/* Faixa de conversão no meio da página. O formulário fica só no fim (~9.000px de
+   rolagem no celular): quem se decidiu ao ler os serviços tinha que rolar tudo de
+   novo. É uma faixa que ancora em #contato, não um segundo formulário — os ids do
+   QuoteForm são fixos e o app.js faz bind em #contactForm, então duas instâncias
+   quebrariam a validação. */
+.cta-band {
+    background: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
+    color: var(--white);
+    padding: 2.5rem 0;
+}
+.cta-band-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+    flex-wrap: wrap;
+}
+.cta-band h2 {
+    font-size: 1.75rem;
+    font-weight: 800;
+    line-height: 1.2;
+}
+.cta-band p {
+    margin-top: 0.375rem;
+    opacity: 0.95;
+}
+.cta-band-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}
+.cta-band-actions .btn {
+    font-size: 1.0625rem;
+    padding: 16px 32px;
+    box-shadow: var(--shadow-lg);
+}
+.cta-band-alt {
+    color: var(--white);
+    font-size: 0.9375rem;
+    text-decoration: underline;
+}
+@media (max-width: 768px) {
+    .cta-band { padding: 1rem 0; }
+    .cta-band-inner { flex-direction: column; text-align: center; gap: 1rem; }
+    .cta-band h2 { font-size: 1.25rem; }
+    .cta-band-actions { width: 100%; }
+}
+
+/* Nota de privacidade junto do submit. O formulário coleta nome, telefone, e-mail,
+   bairro e UTMs e o site não dizia uma palavra sobre isso. Uma linha só, e só o que
+   dá para cumprir: nada de "não compartilhamos", porque os eventos de formulário
+   ainda vão para o GA4. */
+.form-privacy {
+    text-align: center;
+    margin-top: 0.5rem;
+    font-size: 0.8125rem;
+    color: var(--gray);
+    line-height: 1.5;
+}
+
+/* Página de obrigado. Não tinha estilo nenhum: o <div class="thanks-box"> caía
+   colado na esquerda, com um único link de volta. */
+.thanks-box {
+    max-width: 560px;
+    margin: 2.5rem auto 4rem;
+    padding: 0 20px;
+    text-align: center;
+}
+.thanks-box h1 {
+    font-size: 2.25rem;
+    font-weight: 800;
+    margin-bottom: 0.75rem;
+    color: var(--dark);
+}
+.thanks-box > p {
+    color: var(--gray);
+    margin-bottom: 1.5rem;
+}
+.thanks-next {
+    display: block;
+    max-width: 340px;
+    margin: 0 auto;
+}
+.thanks-meta {
+    margin-top: 1rem;
+    font-size: 0.9375rem;
+    color: var(--gray);
+}
+.thanks-meta a {
+    color: var(--primary);
+    font-weight: 600;
+}
+.thanks-back {
+    display: inline-block;
+    margin-top: 1.5rem;
+    color: var(--primary);
+    font-weight: 600;
 }


### PR DESCRIPTION
Nine conversion and UI problems on the landing page, all measured in a real browser against the built preview — before and after — not read off the code.

Rebased on top of #55, so every number below is measured against `main` at `20ff8d7` (identical to `37f95ae` on every metric here — #55 moved none of them). Worth knowing when comparing with earlier notes: #54 reserves a 66px gutter on the right of every container so the floating button stops covering content, which narrows the phone measure from 350px to 304px and by itself added ~510px of wrapping to the home. The mobile scroll baseline moved from 10.449px to 10.962px between the two branches.

## Measured, `main@20ff8d7` → this branch

| What | Where | Before | After |
| --- | --- | --- | --- |
| Home scroll, mobile | 390x844 | 10.962px | **7.611px** (−31%) |
| Home scroll, mobile | 360x800 | 11.388px | 8.335px (−27%) |
| Home scroll, desktop | 1440x900 | 5.367px | 5.334px |
| Neighbourhood scroll, mobile | 390x844 | 10.757px | 6.834px (−36%) |
| H1 lines, home | 1440x900 | 4 | **2** |
| H1 lines, home | 1024x900 | 5 | **2** |
| H1 lines, home | 390x844 | 4 | **3** |
| H1 lines, realengo | 1440 / 390 | 4 / 4 | **2 / 3** |
| H1 lines, freguesia (longest name) | 1440 / 390 | 5 / 5 | **2 / 4** |
| Trust badges inside the fold | 1440x900 | 3 of 5 (last bottom 932px) | **5 of 5** (663px) |
| Trust badges inside the fold | 390x844 | 2 of 5 (last bottom 1.048px) | **5 of 5** (728px) |
| Trust badges inside the fold | 360x800 | 0 of 5 | **5 of 5** (780px) |
| Badge rows | 1440 / 390 | 3+2 / 2+2+1 | **5 / 5 stacked beside the photo** |
| Hero photo visible in the first screen | 390x844 | 0px (starts at 1.077px) | **170px, fully visible** |
| Both hero CTAs in the fold | 390 / 1440 | yes | yes |
| `#submitBtn` background | all | `rgb(15, 95, 158)` | **`rgb(245, 158, 11)`** = hero CTA |
| `.features-grid` rows | 1440 | 4+2 | **3+3** |
| `.testimonials-grid` rows | 1024 | 2+1 | **3** |
| `.footer-content` rows | 1024 | 3+1 | **2+2** |
| Reasons grid rows (neighbourhood) | 1440 | 3+2 | **5** |
| Mobile menu, open | 390 | 310px panel, 20px link targets | **284px**, 48px link targets |
| Menu button state | 390 | three bars, no `aria-expanded` | **`aria-expanded` + close glyph** |
| Privacy mention anywhere on the site | — | none | **one line by the submit** |
| Heading skips, home | 1440 | 2 (`H2→H4`, `H2→H5`) | **0** |
| Horizontal overflow | 360…1440 | none | none |

## One line per item

1. **H1** — the `<br>` was adding a fourth line because "Vidraçaria na Zona Oeste" no longer fit on one at 3.5rem. Two spans instead: promise small on top, metric large below, so they read as two claims and the metric carries the weight. Neighbourhood pages use the same structure, which retires the em dash that only the eye could parse. Between 1024 and 1380 — the range where #54's gutter shrinks the text column — the metric is sized fluidly, measured at ~12.9px of width per px of type, so it never wraps.
2. **Badges** — `grid-auto-flow: column` puts all of them on one row whatever the count (five on the home, four on the neighbourhood pages), so no orphan can form, and `order` moves the rating first because it is the strongest thing in the fold and was the one falling out of it. Text, numbers and DOM order untouched.
3. **Hero photo** — stacked, the photo and the badges could not both fit above 844px, so they share one band right after the CTAs: photo left, badges right. `display: contents` lets two elements from different DOM branches sit side by side without moving the figure, which still has to be the second column on desktop. The documented rule holds — on a phone the button comes before the image.
4. **CTA hierarchy** — amber is bigger, heavier and shadowed; WhatsApp keeps its own green and its link but drops to a smaller secondary, and stops being full-width on the phone. No palette change, `check:contrast` untouched.
5. **Submit colour** — `--cta` exists to be the only colour that means "proceed" and the submit button was the one place ignoring it. Now amber, with the spinner following the label instead of staying white on amber.
6. **Mid-page CTA** — a band right after the six services, which is where the neighbourhood pages already put the form: interest is at its peak, and there are ~5.000px of phone scroll still to go. A band anchoring to `#contato`, not a second `<QuoteForm />` — `#contactForm` and the field ids are fixed and `app.js` binds them, so two instances would break validation.
7. **Vertical rhythm** — section padding, grid gaps and card padding come in; service cards lie down on the phone (icon beside the text, ~2.5 cards per screen instead of one); the checkbox rows become touch targets in their own right instead of a 20px box stretched to 72px by an inherited `min-height`; the two footer link lists go two up. Nothing removed: same sections, same six services, body text never below 16px.
8. **Grids** — `auto-fit` chose columns from the width and ignored the item count. Explicit columns per breakpoint instead: 3+3 at 1440 and 1024, 2+2 in the tablet range, one column on the phone; same for the footer, and a quantity query for the five-item reasons grid, where five is prime and only 1 or 5 columns can close.
9. **Loose ends** — the mobile menu inherited the desktop 2rem gap (the open panel measures 310px on main, not the ~620px in the brief; the gain here is mostly that each link becomes a 48px target instead of 20px in a panel of the same height); the button now carries `aria-expanded` and turns into a close, reflecting the state `app.js` sets rather than duplicating the toggle. A privacy line by the submit, deliberately narrow: it says what the data is used for and stops there. And the thank-you page now opens WhatsApp and repeats the same two-hour promise with the same opening hours the rest of the site publishes, instead of only offering "back to the site".

## Also, since it is the same blocks

The six differentials were `<h4>` and the three client names `<h5>`, both directly under a section `<h2>`, which left the home as the only page with a broken outline after #55. Both are `<h3>` now and the CSS selectors follow the tags. The client name gets an explicit size while we are there: inheriting the `<h5>` default rendered it at 13.3px, smaller than the neighbourhood caption below it. Measured after: home, realengo and obrigado all report zero skips.

## Caught while verifying

- Laying the service cards down with flex put the `<a>` that `whatsapp-cta.js` appends at runtime into a fourth column, pushing the layout to 455px and silently zooming the whole phone viewport out (`innerWidth` 455 against `clientWidth` 390) — which quietly flatters every other measurement. It is a grid now, so any child the script adds lands in the text column.
- Between 1024 and 1380 each badge gets ~105px or less and the labels ran into their neighbours. The icon goes back above the text in that range only.
- `--header-height` from #54 is consumed for the hero's top padding rather than duplicated.
- The 2-up checkbox layout was measured, rendered and then gated to ≥420px: at 390 the reserved gutter leaves ~78px of label and "Janelas de Alumínio" broke into three lines. Below that it stays one column.

## Not done, on purpose

- **Below 7.500px of mobile scroll.** 7.611px is where honest compaction ends. The next ~100px would have to come from the reserved height under each form field, which is there to stop the fields jumping while someone fills them in.
- The privacy line does not say "we don't share your data": `app.js` sends field-level form events to GA4, so that sentence would not be true. It states what the data is used for and nothing more.
- `hoursDisplay` was added to `site.ts` and is consumed only by the thank-you page. The footer and `QuoteForm` still hard-code the same hours; folding them in touches files this PR deliberately stayed out of.

Verified with puppeteer against `npm run preview` at 1440, 1380, 1300, 1280, 1200, 1152, 1100, 1024, 768, 390 and 360: headline lines counted from text-range rects, every badge bottom against the viewport height, badge collisions and label overflow, the photo and both CTAs in the first screen, the computed background of `#submitBtn`, no grid row shorter than the one above it, no horizontal overflow, no console errors, and `npm run build` green including `check:contrast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
