### PR TITLE
fix(float): hide the WhatsApp button when it collides, instead of narrowing every page

### DIFF
--- a/public/js/whatsapp-cta.js
+++ b/public/js/whatsapp-cta.js
@@ -100,6 +100,112 @@ const WhatsAppCTA = {
     },
 
     /**
+     * Estado de visibilidade do flutuante. Ele desaparece em duas situações, e as
+     * duas podem valer ao mesmo tempo — daí flags separadas em vez de um booleano:
+     * a sticky oferece exatamente a mesma ação (redundante), e o formulário na tela
+     * significa que o botão está por cima dos checkboxes (estorvo).
+     */
+    floatState: { stickyVisible: false, formVisible: false, contentUnder: false },
+
+    /**
+     * Aplica o estado ao botão. Chamado pelos dois observadores.
+     */
+    syncFloat() {
+        const btn = document.querySelector('.whatsapp-float');
+        if (!btn) return;
+        const hide = this.floatState.stickyVisible || this.floatState.formVisible || this.floatState.contentUnder;
+        btn.classList.toggle('is-hidden', hide);
+        // Fora da ordem de tabulação enquanto invisível: pointer-events resolve o
+        // mouse, não o teclado.
+        btn.setAttribute('aria-hidden', String(hide));
+        if (hide) btn.setAttribute('tabindex', '-1');
+        else btn.removeAttribute('tabindex');
+    },
+
+    /**
+     * Esconde o flutuante enquanto a seção do formulário estiver na tela: ali ele fica
+     * sobre os checkboxes e é redundante com o próprio formulário.
+     */
+    watchFormVisibility() {
+        const form = document.querySelector('#contato');
+        if (!form || !('IntersectionObserver' in window)) return;
+        new IntersectionObserver((entries) => {
+            this.floatState.formVisible = entries[0].isIntersecting;
+            this.syncFloat();
+        }, { threshold: 0 }).observe(form);
+    },
+
+    /**
+     * Rede de segurança geométrica: esconde o flutuante quando existe DE FATO texto
+     * ou alvo de toque embaixo dele.
+     *
+     * Tentei antes por lista de seletor (.section-subtitle e afins) e passou do ponto:
+     * como esses blocos começam logo abaixo do hero, o botão ficava visível em 7% da
+     * rolagem na home e em NENHUMA parte das páginas de bairro. Aqui o critério é o
+     * pixel, não a estrutura, então não há caso especial por página nem excesso.
+     *
+     * Custo controlado: 5 pontos de amostragem, e a medida do texto usa Range em vez
+     * da caixa do elemento — a caixa de um parágrafo centralizado ocupa a largura
+     * inteira mesmo onde não há glifo nenhum, e era isso que dava falso positivo.
+     */
+    watchContentUnderFloat() {
+        const btn = document.querySelector('.whatsapp-float');
+        if (!btn) return;
+
+        const overlaps = (r, f) =>
+            Math.max(0, Math.min(r.right, f.right) - Math.max(r.left, f.left)) *
+            Math.max(0, Math.min(r.bottom, f.bottom) - Math.max(r.top, f.top)) > 4;
+
+        const test = () => {
+            const f = btn.getBoundingClientRect();
+
+            // Sem isso o próprio botão é o resultado de todo elementsFromPoint.
+            const prev = btn.style.pointerEvents;
+            btn.style.pointerEvents = 'none';
+            const candidates = new Set();
+            const pts = [
+                [f.left + 4, f.top + 4], [f.right - 4, f.top + 4],
+                [f.left + 4, f.bottom - 4], [f.right - 4, f.bottom - 4],
+                [(f.left + f.right) / 2, (f.top + f.bottom) / 2],
+            ];
+            for (const [x, y] of pts) {
+                for (const el of document.elementsFromPoint(x, y)) candidates.add(el);
+            }
+            btn.style.pointerEvents = prev;
+
+            let collides = false;
+            for (const el of candidates) {
+                if (el === btn || btn.contains(el) || el === document.body || el === document.documentElement) continue;
+                if (el.matches('input, select, textarea, button, a')) { collides = true; break; }
+                for (const n of el.childNodes) {
+                    if (n.nodeType !== Node.TEXT_NODE || !n.nodeValue.trim()) continue;
+                    const range = document.createRange();
+                    range.selectNodeContents(n);
+                    for (const r of range.getClientRects()) {
+                        if (overlaps(r, f)) { collides = true; break; }
+                    }
+                    if (collides) break;
+                }
+                if (collides) break;
+            }
+
+            this.floatState.contentUnder = collides;
+            this.syncFloat();
+        };
+
+        let scheduled = false;
+        const schedule = () => {
+            if (scheduled) return;
+            scheduled = true;
+            requestAnimationFrame(() => { scheduled = false; test(); });
+        };
+        window.addEventListener('scroll', schedule, { passive: true });
+        window.addEventListener('resize', schedule);
+        test();
+        console.log('✓ Flutuante recua quando há conteúdo embaixo dele');
+    },
+
+    /**
      * Inicializar otimizações de CTA
      */
     init() {
@@ -117,6 +223,8 @@ const WhatsAppCTA = {
 
         // 3. Melhorar botão flutuante
         this.enhanceFloatingButton();
+        this.watchFormVisibility();
+        this.watchContentUnderFloat();
 
         // 4. Track conversions
         this.trackConversions();
@@ -164,7 +272,11 @@ const WhatsAppCTA = {
                 // Esconder quando volta ao topo
                 stickyBar.classList.remove('active');
             }
-            
+
+            // A sticky e o flutuante são o mesmo CTA: quando ela aparece, ele sai.
+            this.floatState.stickyVisible = stickyBar.classList.contains('active');
+            this.syncFloat();
+
             lastScroll = currentScroll;
         });
         
@@ -231,8 +343,10 @@ const WhatsAppCTA = {
         tooltip.textContent = 'Fale conosco!';
         floatingBtn.appendChild(tooltip);
         
-        // Animar periodicamente para chamar atenção
+        // Animar periodicamente para chamar atenção — mas não enquanto ele está
+        // escondido: sacudir um elemento invisível só gasta frame.
         setInterval(() => {
+            if (floatingBtn.classList.contains('is-hidden')) return;
             floatingBtn.classList.add('shake');
             setTimeout(() => floatingBtn.classList.remove('shake'), 1000);
         }, 15000); // A cada 15 segundos

--- a/src/styles/index-inline.css
+++ b/src/styles/index-inline.css
@@ -50,13 +50,14 @@
                mais 2x16 de padding do .navbar); no mobile o min-height completa. */
             --header-height: 80px;
 
-            /* Área morta do botão flutuante do WhatsApp: diâmetro + folga da borda.
-               O botão é fixed, logo a página inteira desliza por baixo dele — sem
-               reservar essa faixa, texto e checkbox terminam embaixo de um alvo de
-               toque que está sempre por cima. */
+            /* Tamanho e recuo do botão flutuante do WhatsApp. Antes daqui saía também
+               uma --float-safe-area que reservava a faixa do botão no .container
+               inteiro: resolvia a sobreposição, mas estreitava a medida do celular de
+               350 para 304px, custava +513px de rolagem e deixava todo título
+               centralizado 23px fora do centro. Agora o botão se esconde quando
+               atrapalha, e a página não paga nada. */
             --float-size: 60px;
             --float-inset: 30px;
-            --float-safe-area: calc(var(--float-size) + var(--float-inset));
         }
 
         * {
@@ -77,27 +78,6 @@
             max-width: 1200px;
             margin: 0 auto;
             padding: 0 20px;
-        }
-
-        /* 1380px = 1200 do container + 2x a área do flutuante: acima disso a margem
-           lateral que sobra já é maior que o botão e o conteúdo nunca o alcança.
-           Abaixo, o container encosta na borda direita e precisa da folga — senão o
-           flutuante fica em cima do selo "Parcelamos em até 12x", do 3º depoimento e
-           dos checkboxes do formulário, que foi o que acontecia. */
-        @media (max-width: 1380px) {
-            .container {
-                /* A folga é medida da borda da viewport, e os 20px de padding já estão
-                   dentro dela — daí max() e não soma. */
-                padding-right: max(20px, var(--float-safe-area));
-            }
-
-            /* O cabeçalho está preso no topo e o flutuante no rodapé da viewport: eles
-               nunca se cruzam, então o header não paga a folga. Pagando, o menu não
-               cabia entre 769 e ~820px e o botão de orçamento quebrava em duas linhas
-               (header de 100px em vez de 80px). */
-            .header .container {
-                padding-right: 20px;
-            }
         }
 
         .section {
@@ -743,8 +723,10 @@
             animation: spin 0.6s linear infinite;
         }
 
-        /* WhatsApp Floating Button — tamanho e posição vêm dos tokens porque a folga
-           reservada no .container é calculada a partir deles. */
+        /* WhatsApp Floating Button. Ele é fixed, logo a página desliza por baixo —
+           quem resolve a sobreposição é o estado .is-hidden (whatsapp-cta.css),
+           acionado pelo whatsapp-cta.js quando o botão seria redundante ou
+           estorvo. */
         .whatsapp-float {
             position: fixed;
             bottom: var(--float-inset);
@@ -1333,22 +1315,6 @@
     }
 }
 
-/* Abaixo de 1380px o .container reserva a faixa do botão flutuante e a coluna de
-   texto do hero cai de 672px para 582px, depois 406px em 1024. Com corpo fixo a
-   métrica voltava a quebrar em duas linhas; fluido ela fecha em uma em toda a
-   faixa. O medido: a métrica pede ~12.9px de largura por px de corpo. */
-@media (min-width: 1024px) and (max-width: 1380px) {
-    .hero h1 { font-size: clamp(1.875rem, 3vw, 2.8125rem); }
-    .hero-h1-lead { font-size: 1.25rem; }
-    /* Nessa faixa cada selo tem ~105px ou menos: com o ícone ao lado, o rótulo
-       encostava no selo vizinho. Ícone em cima devolve a largura inteira ao texto,
-       e os 5 continuam numa linha. */
-    .trust-badge {
-        flex-direction: column;
-        text-align: center;
-        gap: 0.25rem;
-    }
-}
 
 @media (min-width: 1024px) {
     .hero-grid {

--- a/src/styles/whatsapp-cta.css
+++ b/src/styles/whatsapp-cta.css
@@ -223,6 +223,19 @@
     animation: subtle-pulse 2s infinite;
 }
 
+/* O flutuante sai de cena quando seria redundante ou estorvo: com a barra sticky
+   na tela os dois oferecem a mesma coisa, e com o formulário na tela ele fica em
+   cima dos checkboxes. Some o botão em vez de estreitar a página toda, que era o
+   preço da solução anterior. visibility + pointer-events junto com a opacidade:
+   sem isso ele continua clicável e focável por teclado depois de invisível. */
+.whatsapp-float.is-hidden {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: scale(0.85);
+    animation: none;
+}
+
 /* ============================================================================
    HERO CTA IMPROVEMENTS
    ============================================================================ */


### PR DESCRIPTION
Reverts the page-wide cost of #54's float fix, keeps the fix.

## Why

#54 stopped the floating button covering content by reserving its band on every `.container` below 1380px. It worked — but the page paid:

| cost | measured in production |
|---|---|
| phone measure | 350px → **304px** |
| every centred title | **23px left** of true centre |
| scroll added by the band alone | **+513px** |
| second workaround it forced | #56 made the H1 metric fluid at 1024–1380 and stacked the badge icons, both only because the band squeezed the hero column |

## What this does instead

The button steps aside. Three conditions hide it:

1. the sticky bar is on screen — both offer the same action, one is redundant;
2. the form section is on screen — it sits over the checkboxes;
3. there is genuinely content underneath it.

Condition 3 is **geometric, not structural**. A first attempt keyed off a selector list (`.section-subtitle` and friends) and overshot badly: those blocks start right below the hero, so the button survived in 7% of the scroll on the home and in *none* of the bairro pages. The shipped version samples five points under the button and measures text with `Range` rather than element boxes — a centred paragraph's box spans the full width even where no glyph does, which is exactly what produced false positives in the first place.

With the band gone, #56's compensation is dead code, so it goes too.

## Measured, built output

| | before | after |
|---|---|---|
| container `padding-right` (mobile/tablet) | 66px | **20px** |
| centred title offset | −23px | **0** |
| home scroll @390 | 7611px | **7152px** |
| home scroll @360 | 8335px | **7460px** |
| realengo scroll @390 | 6834px | **6360px** |
| desktop @1440 | 5334px | 5334px (unchanged) |
| float over glyphs or tap targets | 3 collisions | **0**, across 5 pages |
| badges in fold | 5/5 | 5/5 (4/4 on bairro) |
| H1 lines 1024→1440, 3 pages incl. the 38-char worst case | 2 (with fluid clamp) | **2 (no clamp)** |
| badge icon 1024–1380 | stacked | **inline** — intended design restored |

`aria-hidden` and `tabindex="-1"` follow the hidden state, so the button leaves the tab order instead of staying focusable while invisible. Contrast gate passes, no horizontal overflow, 16 pages.

## Consequence worth knowing

The button's visible window shrinks. On the home it shows across 0–30% of the scroll; on bairro pages only 10–13%, and it is hidden even at the fold — correctly, because the bairro hero is shorter and the intro paragraph is already under the button there.

That leaves roughly 13%–30% of the bairro scroll with neither the float nor the sticky bar. Lowering the sticky bar's 30% trigger to ~12% would close it in one line, but that makes the bar more aggressive, so it is a product call and not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)