### PR TITLE
fix(analytics): make the events reach GA4, once each, and say which page they happened on

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,13 @@ verly-lp/
 - Abre navegação (Maps, Waze, etc.)
 
 ### Tracking:
-- Todos os links têm `data-track` para GA4
-- Device info enviado automaticamente
+- Um clique = UM evento. A escolha é por especificidade: WhatsApp → `whatsapp_click`,
+  `tel:` → `phone_click`, `data-track` (e-mail/endereço) → `contact_link_click`, o
+  resto → `navigation_click`.
+- `data-context` nomeia a origem do clique de WhatsApp (`hero-whatsapp`, `cta-band`,
+  `footer-whatsapp`, `floating-button`, `sticky-cta`, `service-*`, `thank-you-page`).
+- Dispositivo, navegador e sistema operacional NÃO são enviados: o GA4 já publica os
+  três como dimensões nativas em todo evento.
 
 ---
 
@@ -201,21 +206,37 @@ verly-lp/
 
 ### Eventos Rastreados:
 
+Todo evento carrega `page_type` (`home`, `bairro`, `blog`, `obrigado`, `erro`) e, nas
+páginas de bairro, `neighborhood_page`. É o que permite comparar a conversão da home
+com a das 11 páginas de bairro.
+
 | Evento | Descrição | Dados Capturados |
 |--------|-----------|------------------|
-| `page_view_with_device` | Carregamento da página | device_type, browser, os |
-| `whatsapp_click` | Clique em WhatsApp | context, device, browser |
-| `contact_link_click` | Clique em telefone/email/endereço | link_type, device, browser |
-| `form_submission` | Envio de formulário | services, neighborhood |
-| `scroll` | Profundidade de scroll | percent (25/50/75/100) |
+| `page_view` | Carregamento da página (o automático do gtag, um por acesso) | page_location, page_title, page_referrer |
+| `whatsapp_click` | Clique em WhatsApp | context, click_source, button_text |
+| `contact_link_click` | Clique em e-mail/endereço | event_name, link_type, link_text |
+| `phone_click` | Clique em `tel:` | phone_number, click_location |
+| `navigation_click` | Clique de navegação (menu, rodapé, âncora) | link_text, link_target, navigation_type |
+| `cta_click` | Clique em botão de CTA | button_text, button_location, target_section |
+| `service_interaction` | Clique em card de serviço | service_name, service_position |
+| `form_interaction` | Cada passo do formulário | form_action, field_name |
+| `generate_lead` | Formulário enviado com sucesso | services, neighborhood, api_status |
+| `scroll` | Profundidade de scroll | percent_scrolled (25/50/75/100) |
 | `section_view` | Visualização de seção | section_name, section_id |
+| `engagement_milestone` | 30s / 60s / 120s na página | milestone_name, milestone_value |
 
 ### Como Ver os Dados:
 ```
 GA4 → Relatórios → Eventos
-- Filtrar por: device_type, browser, os
-- Dimensões customizadas disponíveis
+- Dispositivo, navegador e SO: dimensões nativas, nada a configurar
+- page_type e neighborhood_page precisam ser registrados em
+  Administrador → Definições personalizadas → Dimensões personalizadas
+  (escopo de EVENTO), senão não aparecem em relatório
 ```
+
+### Depurar no Navegador:
+O log de evento é silencioso em produção. Para ligar: `?analytics_debug=1` na URL
+(vale para o acesso) ou `localStorage.setItem('verly_debug', '1')` (fica no aparelho).
 
 **Ver guia completo:** [`docs/GA4_TRACKING_GUIDE.md`](docs/GA4_TRACKING_GUIDE.md)
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -21,40 +21,92 @@ const ADS_CONVERSION_LABEL = '';
 // ============================================================================
 
 /**
+ * Contexto da página, lido UMA vez do <body data-page-type> que o Base.astro escreve
+ * em tempo de build. Vai em todo evento: sem isso não há como responder "as páginas
+ * de bairro convertem melhor que a home?", porque nenhum evento dizia onde aconteceu.
+ *
+ * Vem do servidor, e não de regex em window.location, porque o Astro já sabe o tipo
+ * da página quando gera o HTML — as 11 páginas de bairro saem de um [slug].astro só,
+ * e uma URL nova não pode virar dado errado.
+ */
+const PAGE_CONTEXT = (() => {
+    const data = document.body ? document.body.dataset : {};
+    if (!data.pageType) {
+        console.warn('⚠️ <body data-page-type> ausente — eventos sairão como page_type=unknown');
+    }
+    const context = { page_type: data.pageType || 'unknown' };
+    // Ausente (não vazio) fora das páginas de bairro: parâmetro vazio ainda ocupa
+    // linha no relatório.
+    if (data.neighborhoodPage) context.neighborhood_page = data.neighborhoodPage;
+    return context;
+})();
+
+/**
+ * Interruptor do log de evento. Ligado por `?analytics_debug=1` na URL (vale para o
+ * acesso) ou por `localStorage.setItem('verly_debug', '1')` (fica no aparelho).
+ * Desligado, o visitante não vê nada no console; console.warn/console.error de
+ * condição anormal continuam saindo sempre.
+ */
+const ANALYTICS_DEBUG = (() => {
+    try {
+        if (new URLSearchParams(window.location.search).has('analytics_debug')) return true;
+        return localStorage.getItem('verly_debug') === '1';
+    } catch (error) {
+        // localStorage lança em navegação restrita/iframe de terceiro.
+        return false;
+    }
+})();
+
+function debugLog(...args) {
+    if (ANALYTICS_DEBUG) console.log(...args);
+}
+
+/**
  * Track events to Google Analytics 4
  * @param {string} eventName - GA4 event name (use snake_case)
  * @param {object} eventParams - Event parameters
  */
 function trackGA4Event(eventName, eventParams = {}) {
-    if (typeof gtag !== 'undefined') {
-        // Add common parameters to all events
-        const enrichedParams = {
-            ...eventParams,
-            timestamp: new Date().toISOString(),
-            page_location: window.location.href,
-            page_title: document.title
-        };
-        
-        gtag('event', eventName, enrichedParams);
-        console.log('📊 GA4 Event:', eventName, enrichedParams);
-    } else {
+    if (typeof gtag === 'undefined') {
         console.warn('⚠️ gtag not loaded yet');
+        return;
     }
+    // Sem `timestamp`: o GA4 datava o hit no servidor de qualquer jeito, então o
+    // parâmetro não respondia nenhuma pergunta e gastava cota de dimensão
+    // personalizada em TODO evento.
+    // PAGE_CONTEXT por último: nenhum chamador sobrescreve o tipo da página.
+    const enrichedParams = {
+        ...eventParams,
+        page_location: window.location.href,
+        page_title: document.title,
+        ...PAGE_CONTEXT
+    };
+
+    gtag('event', eventName, enrichedParams);
+    debugLog('📊 GA4 Event:', eventName, enrichedParams);
 }
 
+// O page_view customizado que existia aqui foi removido: junto com o
+// `send_page_view: true` do Base.astro ele contava TODO acesso duas vezes, e
+// pageview é o denominador de toda taxa de conversão. Ficou o automático do GA4,
+// que já traz page_location, page_title e page_referrer.
+// Do que o customizado mandava a mais, nada se perde: user_agent, device_type e
+// screen_resolution são dimensões que o GA4 coleta sozinho em todo hit, e page_path
+// sai de page_location. Só viewport_size não tem equivalente nativo — e não vale uma
+// dimensão personalizada, já que "Resolução da tela" e "Categoria do dispositivo"
+// respondem a mesma pergunta.
+
 /**
- * Track page view (custom implementation)
+ * Exposto para os outros dois scripts de /public. Eles carregam ANTES deste, mas só
+ * chamam depois do DOMContentLoaded, quando isto já existe. Um lugar só enriquece o
+ * evento e um lugar só decide se o log sai.
  */
-function trackPageView() {
-    trackGA4Event('page_view', {
-        page_path: window.location.pathname,
-        page_referrer: document.referrer || 'direct',
-        user_agent: navigator.userAgent,
-        screen_resolution: `${window.screen.width}x${window.screen.height}`,
-        viewport_size: `${window.innerWidth}x${window.innerHeight}`,
-        device_type: getDeviceType()
-    });
-}
+window.VerlyAnalytics = {
+    track: trackGA4Event,
+    log: debugLog,
+    debug: ANALYTICS_DEBUG,
+    pageContext: PAGE_CONTEXT
+};
 
 /**
  * Track CTA button clicks
@@ -121,10 +173,19 @@ function trackServiceClick(serviceName, servicePosition) {
 
 /**
  * Track WhatsApp interaction
+ *
+ * Só os desvios para o WhatsApp que NÃO são clique (fallback e erro do formulário)
+ * passam por aqui. O clique em si tem um emissor só, o ouvinte delegado do
+ * whatsapp-cta.js — ver o comentário em initCompleteAnalytics.
+ *
+ * `context` e `click_source` saem com o mesmo valor de propósito: o evento tem UM
+ * formato só, então uma tabela por qualquer um dos dois parâmetros mostra o
+ * fallback junto dos cliques em vez de "(não definido)".
  */
 function trackWhatsAppClick(source, message = '') {
     trackGA4Event('whatsapp_click', {
-        click_source: source, // 'floating_button', 'hero_cta', 'form_success', 'form_fallback'
+        context: source, // 'form_fallback', 'form_error'
+        click_source: source,
         has_pre_filled_message: !!message,
         message_length: message ? message.length : 0
     });
@@ -138,6 +199,21 @@ function trackPhoneClick(phoneNumber, location) {
         phone_number: phoneNumber,
         click_location: location // 'header', 'contact_section', 'footer'
     });
+}
+
+/**
+ * O clique neste link já tem um evento mais específico que navigation_click?
+ *
+ * navigation_click é para navegação. Contato tem evento próprio: whatsapp_click
+ * (wa.me), phone_click (tel:) e contact_link_click (data-track, hoje e-mail e
+ * endereço). Sem essa regra o mesmo clique aparecia em dois ou três eventos.
+ */
+function hasDedicatedEvent(link) {
+    const href = link.getAttribute('href') || '';
+    return /wa\.me|whatsapp/.test(href)
+        || href.startsWith('tel:')
+        || href.startsWith('mailto:')
+        || link.hasAttribute('data-track');
 }
 
 /**
@@ -495,7 +571,7 @@ async function handleFormSubmit(event) {
         if (response.ok) {
             const text = await response.text();
             const data = text ? JSON.parse(text) : {};
-            console.log('Lead saved successfully:', data);
+            debugLog('Lead saved successfully:', data);
             apiSuccess = true;
         } else {
             console.error('API error:', response.status);
@@ -689,23 +765,21 @@ function initSectionTracking() {
 // ============================================================================
 
 function initCompleteAnalytics() {
-    // Track page load
-    trackPageView();
-    
+    // O page_view sai do gtag('config') no Base.astro, não daqui.
+
     // Track time on page milestones
     setTimeout(() => trackEngagementMilestone('time_30s', 30), 30000);
     setTimeout(() => trackEngagementMilestone('time_60s', 60), 60000);
     setTimeout(() => trackEngagementMilestone('time_120s', 120), 120000);
-    
-    // Track WhatsApp clicks
-    document.querySelectorAll('a[href*="wa.me"], .whatsapp-float').forEach(element => {
-        element.addEventListener('click', () => {
-            const source = element.classList.contains('whatsapp-float') ? 'floating_button' : 
-                          element.closest('.hero') ? 'hero_cta' : 'inline_button';
-            trackWhatsAppClick(source);
-        });
-    });
-    
+
+    // O clique em WhatsApp era rastreado DUAS vezes: este arquivo ligava um ouvinte em
+    // cada `a[href*="wa.me"]` e o whatsapp-cta.js ligava um ouvinte delegado no
+    // document, então cada clique mandava dois `whatsapp_click` com parâmetros
+    // diferentes — e whatsapp_click é o proxy de conversão mais usado do site.
+    // Ficou o delegado: ele lê o `data-context` que o markup já traz (floating-button,
+    // sticky-cta, service-*, footer-whatsapp, thank-you-page), o que é mais preciso que
+    // o hero/inline deduzido aqui, e alcança os CTAs criados em runtime.
+
     // Track ALL CTA clicks with detailed info
     document.querySelectorAll('.btn-primary, .btn-success, .btn-secondary').forEach(button => {
         button.addEventListener('click', (e) => {
@@ -739,6 +813,10 @@ function initCompleteAnalytics() {
     
     // Track footer links
     document.querySelectorAll('.footer a').forEach(link => {
+        // O rodapé mistura navegação (serviços, bairros) com links de contato, e os de
+        // contato já têm evento próprio. Sem este corte, um clique no WhatsApp do rodapé
+        // saía como whatsapp_click + contact_link_click + navigation_click.
+        if (hasDedicatedEvent(link)) return;
         link.addEventListener('click', () => {
             const linkText = link.textContent.trim();
             const linkTarget = link.getAttribute('href');
@@ -819,8 +897,13 @@ function initSmoothScroll() {
             
             e.preventDefault();
             smoothScrollTo(href);
-            
-            // Track internal navigation
+
+            // Só reporta o que mais ninguém reportou: os itens de menu e os links do
+            // rodapé já saem como navigation_click 'menu'/'footer', e uma âncora nos
+            // dois lugares gerava DOIS navigation_click com navigation_type diferente
+            // para um clique só.
+            if (this.classList.contains('nav-link') || this.closest('.footer')) return;
+
             const linkText = this.textContent.trim();
             trackNavigationClick(linkText, href, 'internal_link');
         });
@@ -832,7 +915,7 @@ function initSmoothScroll() {
 // ============================================================================
 
 document.addEventListener('DOMContentLoaded', () => {
-    console.log('🚀 Verly Vidraçaria - App initialized with complete GA4 tracking');
+    debugLog('🚀 Verly Vidraçaria - App initialized with complete GA4 tracking');
     
     // Form validation and submission
     const contactForm = document.getElementById('contactForm');
@@ -876,7 +959,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initSectionTracking();
     initCompleteAnalytics();
     
-    console.log('✅ GA4 tracking initialized with 15+ event types');
+    debugLog('✅ GA4 tracking initialized with 15+ event types');
 });
 
 // ============================================================================

--- a/public/js/ui-improvements.js
+++ b/public/js/ui-improvements.js
@@ -583,8 +583,17 @@ const AccessibilityEnhancer = {
 // INITIALIZE ALL IMPROVEMENTS
 // ============================================================================
 
+/**
+ * Log de passo do carregamento fica atrás do mesmo interruptor dos eventos
+ * (app.js: `?analytics_debug=1` ou localStorage `verly_debug`), em vez de aparecer no
+ * console de todo visitante.
+ */
+function uiDebugLog(...args) {
+    if (window.VerlyAnalytics) window.VerlyAnalytics.log(...args);
+}
+
 function initUIImprovements() {
-    console.log('🎨 Initializing UI/UX improvements...');
+    uiDebugLog('🎨 Initializing UI/UX improvements...');
     
     // Initialize components
     ToastManager.init();
@@ -593,7 +602,7 @@ function initUIImprovements() {
     SearchableSelect.init();
     AccessibilityEnhancer.init();
     
-    console.log('✅ UI/UX improvements loaded');
+    uiDebugLog('✅ UI/UX improvements loaded');
 }
 
 // Initialize when DOM is ready

--- a/public/js/whatsapp-cta.js
+++ b/public/js/whatsapp-cta.js
@@ -9,52 +9,32 @@
  * - Mensagens contextualizadas aumentam engajamento em 40%
  */
 
+/**
+ * Todo evento daqui passa pelo trackGA4Event do app.js: é ele que carimba
+ * page_type/neighborhood_page e decide se o log sai. Um lugar só enriquece, então
+ * nenhum evento escapa sem o contexto da página.
+ *
+ * app.js carrega DEPOIS deste arquivo (ver a ordem em Base.astro), mas tudo aqui só
+ * dispara a partir do DOMContentLoaded, quando window.VerlyAnalytics já existe.
+ *
+ * Prefixo `cta` porque os três scripts de /public são clássicos e dividem o MESMO
+ * escopo global — um `track`/`log` solto aqui esbarraria no vizinho sem avisar.
+ */
+function ctaTrack(eventName, eventParams) {
+    if (window.VerlyAnalytics) {
+        window.VerlyAnalytics.track(eventName, eventParams);
+    } else {
+        console.warn('⚠️ VerlyAnalytics indisponível — evento não enviado:', eventName);
+    }
+}
+
+function ctaLog(...args) {
+    if (window.VerlyAnalytics) window.VerlyAnalytics.log(...args);
+}
+
 const WhatsAppCTA = {
     phone: '5521987926578',
-    
-    /**
-     * Detectar informações do dispositivo e navegador
-     */
-    getDeviceInfo() {
-        const ua = navigator.userAgent;
-        
-        // Detectar tipo de dispositivo
-        const isIOS = /iPhone|iPad|iPod/i.test(ua);
-        const isAndroid = /Android/i.test(ua);
-        const isMobile = isIOS || isAndroid || /Mobile/i.test(ua);
-        
-        let deviceType = 'Desktop';
-        if (isIOS) deviceType = 'iOS';
-        else if (isAndroid) deviceType = 'Android';
-        else if (isMobile) deviceType = 'Mobile';
-        
-        // Detectar navegador
-        let browser = 'Unknown';
-        if (ua.includes('Chrome') && !ua.includes('Edg')) browser = 'Chrome';
-        else if (ua.includes('Safari') && !ua.includes('Chrome')) browser = 'Safari';
-        else if (ua.includes('Firefox')) browser = 'Firefox';
-        else if (ua.includes('Edg')) browser = 'Edge';
-        else if (ua.includes('Opera') || ua.includes('OPR')) browser = 'Opera';
-        
-        // Detectar sistema operacional
-        let os = 'Unknown';
-        if (ua.includes('Windows')) os = 'Windows';
-        else if (ua.includes('Mac')) os = 'macOS';
-        else if (ua.includes('Linux')) os = 'Linux';
-        else if (isIOS) os = 'iOS';
-        else if (isAndroid) os = 'Android';
-        
-        return {
-            deviceType,
-            browser,
-            os,
-            isMobile,
-            isIOS,
-            isAndroid,
-            userAgent: ua
-        };
-    },
-    
+
     /**
      * Link do WhatsApp com a mensagem já preenchida.
      *
@@ -202,14 +182,14 @@ const WhatsAppCTA = {
         window.addEventListener('scroll', schedule, { passive: true });
         window.addEventListener('resize', schedule);
         test();
-        console.log('✓ Flutuante recua quando há conteúdo embaixo dele');
+        ctaLog('✓ Flutuante recua quando há conteúdo embaixo dele');
     },
 
     /**
      * Inicializar otimizações de CTA
      */
     init() {
-        console.log('🚀 WhatsApp CTA Optimization iniciado');
+        ctaLog('🚀 WhatsApp CTA Optimization iniciado');
 
         // Os links que o Astro renderiza já saem prontos (src/data/site.ts). O que
         // existia aqui era um passe reescrevendo TODOS eles para web.whatsapp.com;
@@ -229,7 +209,7 @@ const WhatsAppCTA = {
         // 4. Track conversions
         this.trackConversions();
 
-        console.log('✅ Otimizações aplicadas');
+        ctaLog('✅ Otimizações aplicadas');
     },
 
     /**
@@ -280,7 +260,7 @@ const WhatsAppCTA = {
             lastScroll = currentScroll;
         });
         
-        console.log('✓ Sticky CTA adicionado');
+        ctaLog('✓ Sticky CTA adicionado');
     },
 
     /**
@@ -324,7 +304,7 @@ const WhatsAppCTA = {
             }
         });
         
-        console.log(`✓ ${addedCount} CTAs de serviços adicionados (incluindo Espelhos e Divisórias)`);
+        ctaLog(`✓ ${addedCount} CTAs de serviços adicionados (incluindo Espelhos e Divisórias)`);
     },
 
     /**
@@ -360,76 +340,76 @@ const WhatsAppCTA = {
             tooltip.classList.remove('visible');
         });
         
-        console.log('✓ Botão flutuante melhorado');
+        ctaLog('✓ Botão flutuante melhorado');
     },
 
     /**
-     * Track conversions para analytics com informações de dispositivo
+     * Track conversions para analytics
+     *
+     * O evento `page_view_with_device` que saía daqui no carregamento foi removido:
+     * ele existia só para carregar device_type/browser/os, que são atributo do acesso
+     * e não evento próprio — e o GA4 já publica os três como dimensões nativas
+     * (Categoria do dispositivo, Navegador, Sistema operacional) em TODO hit. Como
+     * evento separado ele só inflava a contagem e não cruzava com nada. Por isso os
+     * três também saíram dos eventos abaixo: eram cópia do que o GA4 mede sozinho.
      */
     trackConversions() {
-        const deviceInfo = this.getDeviceInfo();
-        
-        // Enviar informações de dispositivo para GA4 no carregamento da página
-        if (typeof gtag !== 'undefined') {
-            gtag('event', 'page_view_with_device', {
-                device_type: deviceInfo.deviceType,
-                browser: deviceInfo.browser,
-                os: deviceInfo.os,
-                is_mobile: deviceInfo.isMobile,
-                page_location: window.location.href
-            });
-            
-            console.log('📊 Device info enviado para GA4:', deviceInfo);
-        }
-        
-        // Rastrear cliques em WhatsApp
+        /**
+         * ÚNICO emissor de whatsapp_click do site. O app.js também ligava um ouvinte em
+         * cada `a[href*="wa.me"]`, então um clique saía como DOIS whatsapp_click com
+         * parâmetros disjuntos — um só com `click_source`, outro só com `context` — o que
+         * dobra o volume e joga metade de qualquer tabela por origem em "(não definido)".
+         *
+         * Ficou o delegado, e não o por elemento, porque ele alcança os CTAs criados em
+         * runtime (a sticky e os 6 dos cards de serviço) e lê o `data-context` que o
+         * markup já traz. Os DOIS parâmetros continuam saindo: `context` é a origem
+         * nomeada na página, `click_source` é a categoria que o ouvinte do app.js
+         * calculava — nada se perde na consolidação.
+         */
         document.addEventListener('click', (e) => {
             const target = e.target.closest('a[href*="whatsapp"], a[href*="wa.me"]');
-            
+
             if (target) {
                 const context = target.dataset.context || 'unknown';
-                const buttonText = target.textContent.trim();
-                
-                // Google Analytics 4
-                if (typeof gtag !== 'undefined') {
-                    gtag('event', 'whatsapp_click', {
-                        context: context,
-                        button_text: buttonText,
-                        device_type: deviceInfo.deviceType,
-                        browser: deviceInfo.browser,
-                        os: deviceInfo.os,
-                        page_location: window.location.href,
-                        timestamp: new Date().toISOString()
-                    });
-                }
-                
-                console.log(`📊 WhatsApp click tracked: ${context} (${deviceInfo.deviceType})`);
+                const clickSource = target.classList.contains('whatsapp-float')
+                    ? 'floating_button'
+                    : target.closest('.hero')
+                        ? 'hero_cta'
+                        : 'inline_button';
+
+                ctaTrack('whatsapp_click', {
+                    context: context,
+                    click_source: clickSource,
+                    button_text: target.textContent.trim()
+                });
+
+                ctaLog(`📊 WhatsApp click tracked: ${context} (${clickSource})`);
             }
         });
-        
-        // Rastrear cliques em links com data-track (telefone, endereço, email)
+
+        // Rastrear cliques em links com data-track (endereço, email)
         document.addEventListener('click', (e) => {
             const target = e.target.closest('[data-track]');
-            
+
             if (target) {
+                const href = target.getAttribute('href') || '';
+                // Um clique = um evento. WhatsApp já sai como whatsapp_click e telefone
+                // como phone_click (app.js); sem este corte, um data-track nesses links
+                // faz o mesmo clique contar duas vezes — era o caso do WhatsApp e do
+                // telefone do rodapé.
+                if (/wa\.me|whatsapp/.test(href) || href.startsWith('tel:')) return;
+
                 const trackEvent = target.dataset.track;
-                const linkType = target.getAttribute('href')?.split(':')[0] || 'unknown';
+                const linkType = href.split(':')[0] || 'unknown';
                 const linkText = target.textContent.trim();
-                
-                if (typeof gtag !== 'undefined') {
-                    gtag('event', 'contact_link_click', {
-                        event_name: trackEvent,
-                        link_type: linkType,
-                        link_text: linkText,
-                        device_type: deviceInfo.deviceType,
-                        browser: deviceInfo.browser,
-                        os: deviceInfo.os,
-                        page_location: window.location.href,
-                        timestamp: new Date().toISOString()
-                    });
-                }
-                
-                console.log(`📊 Contact link tracked: ${trackEvent} (${linkType}) - ${deviceInfo.deviceType}`);
+
+                ctaTrack('contact_link_click', {
+                    event_name: trackEvent,
+                    link_type: linkType,
+                    link_text: linkText
+                });
+
+                ctaLog(`📊 Contact link tracked: ${trackEvent} (${linkType})`);
             }
         });
     }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -55,16 +55,20 @@ const year = new Date().getFullYear();
         </ul>
       </div>
 
+      {/* `data-track` só onde contact_link_click é o ÚNICO evento do clique — hoje
+          e-mail e endereço. O link de WhatsApp já sai como whatsapp_click (data-context)
+          e o telefone como phone_click, então o data-track deles fazia o mesmo clique
+          virar dois eventos. */}
       <div class="footer-section">
         <h2>Contato</h2>
         <p>
           <Icon name="whatsapp" />
-          <a href={CONTACT.whatsappFooter} target="_blank" rel="noopener noreferrer" class="footer-contact-link whatsapp-link" data-context="footer-whatsapp" data-track="footer_whatsapp_click">
+          <a href={CONTACT.whatsappFooter} target="_blank" rel="noopener noreferrer" class="footer-contact-link whatsapp-link" data-context="footer-whatsapp">
             {CONTACT.mobileDisplay}
           </a>
           <br />
           <Icon name="phone" />
-          <a href={`tel:${CONTACT.landline}`} class="footer-contact-link phone-link" data-track="footer_phone_click">
+          <a href={`tel:${CONTACT.landline}`} class="footer-contact-link phone-link">
             {CONTACT.landlineDisplay}
           </a>
           <br />

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -21,6 +21,19 @@ interface Props {
   ogTitle?: string;
   ogDescription?: string;
   ogImage?: string;
+  /**
+   * Tipo de página no analytics. Desce para `<body data-page-type>` — o mesmo caminho
+   * que home/hasForm/hasServices já usam — e de lá app.js carimba TODO evento, que é
+   * o que permite perguntar "as páginas de bairro convertem melhor que a home?".
+   *
+   * Vem daqui e não de regex em window.location porque o Astro já sabe o tipo quando
+   * gera o HTML, e as 11 páginas de bairro nascem de um único [slug].astro.
+   * Obrigatório de propósito: o build quebra se uma página nova esquecer, o que é
+   * melhor que descobrir o buraco no relatório meses depois.
+   */
+  pageType: 'home' | 'bairro' | 'blog' | 'obrigado' | 'erro';
+  /** nome do bairro; só as páginas de bairro preenchem */
+  neighborhoodPage?: string;
   /** true só na home — decide se as âncoras do nav são locais ou saltam pro index */
   home?: boolean;
   /** a página traz o formulário? decide se o nav aponta #contato local */
@@ -47,6 +60,8 @@ const {
   ogTitle,
   ogDescription,
   ogImage,
+  pageType,
+  neighborhoodPage,
   home = false,
   hasForm = false,
   hasServices = false,
@@ -58,6 +73,12 @@ const {
 } = Astro.props;
 
 const canonical = `${SITE_URL}${canonicalPath}`;
+
+// Gate de build: sem pageType, todo evento da página sairia como 'unknown' e a
+// segmentação por tipo de página morreria em silêncio.
+if (!pageType) {
+  throw new Error(`Base.astro: pageType é obrigatório (página ${canonicalPath}).`);
+}
 
 // O thumb de compartilhamento sai da MESMA imagem que a página exibe. Antes era
 // `/img/logo.png` fixo: trocar a foto da loja não mudava o preview no WhatsApp, e o
@@ -103,15 +124,36 @@ const ogImageUrl = ogImage ?? `${SITE_URL}${ogFallback.src}`;
 
     <!-- Google Analytics 4 + Google Ads (carregado verbatim do site atual) -->
     <script is:inline async src={`https://www.googletagmanager.com/gtag/js?id=${ANALYTICS.ga4}`}></script>
-    <script is:inline define:vars={{ ga4: ANALYTICS.ga4, ads: ANALYTICS.googleAds }}>
+    {/* Duas coisas neste bloco não são óbvias, e o comentário fica AQUI (comentário
+        Astro não vai para o HTML) porque este script viaja em todas as 16 páginas.
+
+        1. `window.gtag`: `define:vars` faz o Astro embrulhar o script num IIFE, então
+           `function gtag()` ficava presa na closure e window.gtag nunca existia.
+           Resultado: todo `typeof gtag !== 'undefined'` dos scripts de /public dava
+           falso e NENHUM evento customizado saía do site — só o page_view automático.
+        2. page_type/neighborhood_page no config, além do trackGA4Event: quem manda o
+           page_view é a biblioteca (send_page_view), e parâmetro de config é o único
+           jeito de ele sair com o contexto da página. Esse evento é o denominador de
+           toda taxa de conversão, então é o que mais precisa da segmentação. */}
+    <script
+      is:inline
+      define:vars={{
+        ga4: ANALYTICS.ga4,
+        ads: ANALYTICS.googleAds,
+        pageType,
+        neighborhoodPage: neighborhoodPage ?? '',
+      }}
+    >
       window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
+      window.gtag = function gtag() {
+        window.dataLayer.push(arguments);
+      };
       gtag('js', new Date());
       gtag('config', ga4, {
         send_page_view: true,
         cookie_flags: 'SameSite=None;Secure',
+        page_type: pageType,
+        ...(neighborhoodPage ? { neighborhood_page: neighborhoodPage } : {}),
       });
       gtag('config', ads);
     </script>
@@ -135,7 +177,11 @@ const ogImageUrl = ogImage ?? `${SITE_URL}${ogFallback.src}`;
     <slot name="head" />
   </head>
 
-  <body class={bodyClass}>
+  <body
+    class={bodyClass}
+    data-page-type={pageType}
+    data-neighborhood-page={neighborhoodPage || undefined}
+  >
     <header class="header">
       <div class="container">
         <Nav home={home} hasForm={hasForm} hasServices={hasServices} hasDifferentials={hasDifferentials} />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -6,6 +6,7 @@ import Base from '../layouts/Base.astro';
   title={'Página não encontrada - Verly Vidraçaria'}
   description={'Verly Vidraçaria — vidros temperados e alumínio na Zona Oeste do Rio de Janeiro.'}
   canonicalPath="/404.html"
+  pageType="erro"
   schema={false}
 >
 

--- a/src/pages/500.astro
+++ b/src/pages/500.astro
@@ -6,6 +6,7 @@ import Base from '../layouts/Base.astro';
   title={'Erro no servidor - Verly Vidraçaria'}
   description={'Verly Vidraçaria — vidros temperados e alumínio na Zona Oeste do Rio de Janeiro.'}
   canonicalPath="/500.html"
+  pageType="erro"
   schema={false}
 >
 

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -40,6 +40,8 @@ const faqSchema =
   robots={n.robots ?? undefined}
   ogImage={n.ogImage ?? undefined}
   includeRating={n.hasRating}
+  pageType="bairro"
+  neighborhoodPage={n.name}
   hasForm={true}
   hasServices={true}
   hasDifferentials={true}
@@ -66,7 +68,7 @@ const faqSchema =
           <a href="#contato" class="btn btn-success btn-lg">
             <Icon name="clipboard-check" /> Solicitar Orçamento Grátis
           </a>
-          <a href={CONTACT.whatsappDirect} target="_blank" rel="noopener" class="btn btn-whatsapp btn-lg">
+          <a href={CONTACT.whatsappDirect} target="_blank" rel="noopener" class="btn btn-whatsapp btn-lg" data-context="hero-whatsapp">
             <Icon name="whatsapp" /> WhatsApp Direto
           </a>
         </div>

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -8,6 +8,7 @@ import Base from '../layouts/Base.astro';
   canonicalPath="/blog.html"
   ogImage="https://verlyvidracaria.com/img/portfolio/cortina.jpg"
   keywords={'dicas vidros, manutenção box blindex, limpeza vidros temperados, cuidados com alumínio, blog vidraçaria'}
+  pageType="blog"
   schema={false}
 >
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,6 +15,7 @@ import { CONTACT } from '../data/site';
   ogTitle={'Verly Vidraçaria | Vidros Temperados e Box Blindex na Zona Oeste RJ'}
   ogDescription={'Especialista em vidros temperados, box blindex, cortinas de vidro e soluções em alumínio na Zona Oeste do Rio de Janeiro.'}
   ogUrl="https://verlyvidracaria.com"
+  pageType="home"
   home={true}
   hasForm={true}
 >
@@ -44,7 +45,11 @@ import { CONTACT } from '../data/site';
                     <a href="#contato" class="btn btn-success btn-lg">
                         <Icon name="clipboard-check" /> Solicitar Orçamento Grátis
                     </a>
-                    <a href="https://wa.me/5521987926578?text=Ol%C3%A1%2C%20gostaria%20de%20solicitar%20um%20or%C3%A7amento!" target="_blank" class="btn btn-whatsapp btn-lg">
+                    {/* data-context nomeia a origem do clique no whatsapp_click. Sem ele o
+                        evento saía como context="unknown", e este é o CTA mais exposto da
+                        página. O mesmo valor vale no hero das páginas de bairro: quem separa
+                        home de bairro agora é o page_type. */}
+                    <a href="https://wa.me/5521987926578?text=Ol%C3%A1%2C%20gostaria%20de%20solicitar%20um%20or%C3%A7amento!" target="_blank" class="btn btn-whatsapp btn-lg" data-context="hero-whatsapp">
                         <Icon name="whatsapp" /> WhatsApp Direto
                     </a>
                 </div>
@@ -163,7 +168,7 @@ import { CONTACT } from '../data/site';
                 <a href="#contato" class="btn btn-success">
                     <Icon name="clipboard-check" /> Solicitar Orçamento Grátis
                 </a>
-                <a href={CONTACT.whatsappDirect} target="_blank" rel="noopener" class="cta-band-alt">
+                <a href={CONTACT.whatsappDirect} target="_blank" rel="noopener" class="cta-band-alt" data-context="cta-band">
                     ou fale direto no WhatsApp
                 </a>
             </div>

--- a/src/pages/obrigado.astro
+++ b/src/pages/obrigado.astro
@@ -8,6 +8,7 @@ import { CONTACT } from '../data/site';
   title={'Obrigado pelo seu contato!'}
   description={'Verly Vidraçaria — vidros temperados e alumínio na Zona Oeste do Rio de Janeiro.'}
   canonicalPath="/obrigado.html"
+  pageType="obrigado"
   schema={false}
 >
 


### PR DESCRIPTION
Six data-quality defects in the landing page instrumentation. Everything below was
measured in a browser against the built preview — `window.gtag` replaced by a
collector, plus the `/g/collect` requests read off the wire — not inferred from the
code. The form was never submitted: that POST creates a real lead in the shop.

## What was wrong, and what it is now

| # | Item | What was wrong | Fix | Measured |
|---|------|----------------|-----|----------|
| 0 | **The whole taxonomy was dead** (`src/layouts/Base.astro:132`) | `define:vars` makes Astro wrap the inline script in an IIFE, so `function gtag()` never reached `window`. Every `typeof gtag !== 'undefined'` guard in the three `/public` scripts was false, so no custom event ever left the site | `window.gtag = function gtag() {...}` | custom events in one home session: **0 → 27** |
| 1 | `page_view` counted twice (`Base.astro:113` + `app.js:693`) | Real in the code, but **latent**: the custom `page_view` could never fire, so the wire always carried one. It would have doubled the moment #0 landed | custom `trackPageView()` and its call removed; the automatic `page_view` is the survivor | `en=page_view` per load: **1 → 1** (0 explicit `gtag('event','page_view')`) |
| 2 | `timestamp` on every event (`app.js:33`, `whatsapp-cta.js:402,428`) | GA4 stamps the hit server-side; the param answered nothing and burned dimension quota on every event | removed from all three call sites | events carrying `timestamp`: **all → 0** |
| 3 | No page segmentation | Nothing said where an event happened, so "do the bairro pages convert better than the home?" had no answer | required `pageType` prop → `<body data-page-type>` → read once in `trackGA4Event`; same values into `gtag('config')` so the automatic `page_view` carries them too | events with correct `page_type`: **0 → 100%**, 4 pages × 2 viewports; `neighborhood_page` only on bairro |
| 4 | `console.log` of every event in production | `📊 GA4 Event: …` plus ~12 loading steps shipped to every visitor | behind `?analytics_debug=1` or `localStorage verly_debug=1`; `console.warn`/`error` untouched | `console.log` per load: **27–47 → 0** (**40** with the switch on) |
| 5 | `whatsapp_click` double-counted (`app.js:701` + `whatsapp-cta.js:386`) | Two independent listeners, disjoint params — one with `click_source`, one with `context` — so half of any table by origin fell into "(not set)" | one emitter: the delegated one (reaches runtime-created CTAs, reads `data-context`), now sending **both** params | per hero click: **2 → 1** |
| 5a | 3 CTAs without `data-context` (`index.astro:48,167`, `[slug].astro:71`) | The most exposed CTAs on the site reported `context="unknown"` | `hero-whatsapp`, `cta-band`, `hero-whatsapp` (both heroes share the value — `page_type` separates home from bairro now) | `whatsapp_click` with `context=unknown`: **3 CTAs → 0** |
| 5b | Footer quadrupled (`Footer.astro:62,67`) | The WhatsApp link had `data-context` **and** `data-track` and sat under a site-wide navigation listener | one click = one event, by specificity: WhatsApp → `whatsapp_click`, `tel:` → `phone_click`, `data-track` → `contact_link_click`, rest → `navigation_click` | footer WhatsApp **4 → 1**, footer phone **3 → 1**, e-mail/address **2 → 1**, menu/footer anchor **2 → 1** |
| 6 | `page_view_with_device` (`whatsapp-cta.js:374`) | A second load event existing only to carry `device_type`, `browser`, `os` — attributes of the visit, and GA4 already publishes all three as native dimensions | event deleted, the three params dropped from the remaining events rather than moved | one event fewer per load; `getDeviceInfo()` went with it |

No event was renamed and no event was invented. Nothing was touched in Google Ads,
`ADS_CONVERSION_LABEL`, consent, layout, CSS, copy or the form.

## How it was verified

`npm run build` (contrast gate + 16 pages) and then puppeteer against
`astro preview`, on `/`, `/realengo.html`, `/blog.html` and `/obrigado.html`, at
1440x900 and 390x844:

- **What the site sends**: `evaluateOnNewDocument` patches `dataLayer.push` and
  records every `gtag('event', …)` and `gtag('config', …)`, with
  `googletagmanager.com` blocked so `gtag` stays the stub. Per combination:
  event count, param set, `page_type` against the expected value.
- **What goes on the wire**: same run with the real library loading, recording and
  then **aborting** every `/g/collect` request (the GA4 property is the owner's
  production one and must not receive localhost traffic). Result: exactly one
  `en=page_view` per load, `tid=G-GDQV6C1NWH`, carrying `ep.page_type` and
  `ep.neighborhood_page`. Note that aborting makes the library fail over to a second
  host with the same `_p`/`_s`, so hits are deduped by `(tid, _p, _s)` — the raw
  count of two hits is one event, which is also why the "before" number is 1.
- **One event per click**: one page load per target, one click, count. Baseline
  measured on a preview built from `origin/main`'s three JS files **with the gtag fix
  applied**, since on `origin/main` nothing fires at all and the duplicates are
  invisible. That reproduced the double `whatsapp_click`, the `context="unknown"` and
  the 4-event footer click exactly.
- **Interactions were safe**: scroll, section views, focus/fill/blur on the fields, a
  checkbox, and clicks with a capture-phase `preventDefault` installed by the harness.
  **The form was never submitted.** `generate_lead` was verified by reading its single
  call site and by invoking the same `trackGA4Event` in the page: it comes out with
  `page_type` (and `neighborhood_page` on realengo) and no `timestamp`.

## For the owner: register these in the GA4 UI

Two new params. Without registration they arrive but do not appear in reports —
Admin → Custom definitions → Custom dimensions:

| Parameter | Scope |
|-----------|-------|
| `page_type` | Event |
| `neighborhood_page` | Event |

`click_source` is worth registering too if you want to break `whatsapp_click` down by
it; `context` was already being sent (into a void, given #0).

## Left out on purpose

- The custom `scroll` event colliding with GA4 Enhanced Measurement, and `services`
  overflowing the 100-char param limit: separate PR, both need a decision.
- A click on a service-card WhatsApp button still sends `service_interaction` **and**
  `whatsapp_click` (2 events, distinct names, one nested inside the other) — same for
  a CTA button that is also an anchor (`cta_click` + `navigation_click`). Those are
  not duplicates of one name; whether they should collapse is a product call.
- The spec of the end state lives in #58 (`docs/ANALYTICS_PLAN.md`); nothing in
  `docs/` was touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
