### PR TITLE
feat(social proof): publish the reviews that exist, and only those

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,10 +313,10 @@ node whatsapp-cta-test.js
 5. **Floating Button:** WhatsApp fixo no canto (desktop/mobile)
 
 ### Prova Social:
-- 4.8★ (127 avaliações)
-- 3 depoimentos de clientes reais
+- 5,0★ no Google (nota do Google Business Profile; a contagem não vai para a tela)
+- 3 depoimentos copiados na íntegra do perfil do Google
 - Mais de 10 anos de experiência
-- 127+ projetos realizados
+- Loja física em Realengo, com foto da fachada no hero
 
 ### Senso de Urgência:
 - "Orçamento em até 2 Horas"

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import Icon from '../components/Icon.astro';
-import { CONTACT, SERVICES, FOOTER_NEIGHBORHOODS } from '../data/site';
+import { CONTACT, SERVICES, FOOTER_NEIGHBORHOODS, GOOGLE_REVIEWS } from '../data/site';
 
 interface Props {
   home?: boolean;
@@ -31,8 +31,10 @@ const year = new Date().getFullYear();
       <div class="footer-section">
         <h2>Verly Vidraçaria</h2>
         <p>Especialista em vidros temperados e soluções em alumínio na Zona Oeste do Rio de Janeiro.</p>
+        {/* A nota vem do Google Business Profile; a contagem, não — ela fica só no
+            aggregateRating do LocalBusiness, que exige o campo. Ver GOOGLE_REVIEWS. */}
         <p style="margin-top: 1rem;">
-          <strong>4.8★</strong> (127 avaliações)<br />
+          <strong>{GOOGLE_REVIEWS.ratingDisplay}★</strong> no Google<br />
           Mais de 10 anos de experiência
         </p>
       </div>

--- a/src/components/LocalBusinessSchema.astro
+++ b/src/components/LocalBusinessSchema.astro
@@ -1,5 +1,5 @@
 ---
-import { SITE_URL, CONTACT, ANALYTICS } from '../data/site';
+import { SITE_URL, CONTACT, ANALYTICS, GOOGLE_REVIEWS } from '../data/site';
 import neighborhoods from '../data/neighborhoods.json';
 
 interface Props {
@@ -11,10 +11,13 @@ interface Props {
 const { includeRating = true, image } = Astro.props;
 
 // Schema LocalBusiness — antes duplicado em cada página HTML, agora gerado.
-// NOTA: aggregateRating 4.8 / 127 é carregado VERBATIM do site atual por decisão
-// explícita (2026-08-07). O número não corresponde ao Google Business Profile e
-// segue como item de risco em aberto — structured data inflado pode custar o
-// rich result. Trocar quando as avaliações reais entrarem (Fase 3).
+// O aggregateRating saía daqui com 4,8 / 127: números herdados do site antigo, sem
+// fonte, e por isso registrados como risco em aberto em 2026-08-07 — structured data
+// que não bate com o Google Business Profile custa o rich result inteiro, não só a
+// estrela inflada. O risco está FECHADO em 2026-08-10: a nota e a contagem passaram a
+// vir de GOOGLE_REVIEWS, que espelha o perfil real da loja (15 avaliações, todas 5
+// estrelas). A contagem não aparece em lugar nenhum da interface, por decisão do dono;
+// ela existe aqui porque o schema.org exige reviewCount dentro de aggregateRating.
 const schema = {
   '@context': 'https://schema.org',
   '@type': 'LocalBusiness',
@@ -63,7 +66,13 @@ const schema = {
   ],
   sameAs: ['https://facebook.com/verlyvidracaria', 'https://instagram.com/verlyvidracaria'],
   ...(includeRating
-    ? { aggregateRating: { '@type': 'AggregateRating', ratingValue: '4.8', reviewCount: '127' } }
+    ? {
+        aggregateRating: {
+          '@type': 'AggregateRating',
+          ratingValue: GOOGLE_REVIEWS.ratingValue,
+          reviewCount: GOOGLE_REVIEWS.reviewCount,
+        },
+      }
     : {}),
 };
 ---

--- a/src/components/QuoteForm.astro
+++ b/src/components/QuoteForm.astro
@@ -76,8 +76,13 @@ const {
                             <Icon name="award" />
                         </div>
                         <div class="contact-item-content">
+                            {/* "Mais de 127 projetos realizados" saiu daqui: o 127 era a
+                                contagem falsa de avaliações reciclada como contagem de obras,
+                                e não existe registro que a sustente. O que sustenta a garantia
+                                é o que dá para conferir — a loja tem endereço, fachada e uma
+                                década de porta aberta. */}
                             <strong>Garantia de Qualidade</strong>
-                            <p>Mais de 127 projetos realizados com sucesso</p>
+                            <p>Mais de 10 anos de experiência, com loja física em Realengo</p>
                         </div>
                     </div>
                 </div>

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -34,9 +34,73 @@ export const CONTACT = {
     locality: 'Realengo',
     region: 'RJ',
     postalCode: '21765-000',
-    lat: -22.8814,
-    lng: -43.4251,
+    // Coordenadas do próprio perfil do Google da loja. As anteriores (-22.8814,
+    // -43.4251) erravam por ~700 m e iam publicadas no `geo` do LocalBusiness: o site
+    // afirmava, em dado estruturado, uma localização onde a loja não está.
+    lat: -22.8855432,
+    lng: -43.4305539,
   },
+};
+
+/**
+ * Avaliações do Google Business Profile da loja. Snapshot de 10/08/2026:
+ * 15 avaliações, todas 5 estrelas.
+ *
+ * Antes daqui saíam 4,8★ e 127 avaliações — números herdados do site antigo, sem
+ * nenhuma fonte. Agora só entra aqui o que o perfil do Google mostra: nada de
+ * estimativa, arredondamento ou "mais de".
+ *
+ * A CONTAGEM não vai para a tela, por decisão do dono: quinze é número pequeno
+ * demais para vender, a nota é que vende. Ela sobrevive em `reviewCount` porque o
+ * aggregateRating do schema.org exige o campo — quem abrir o código-fonte lê 15, e
+ * isso é melhor que publicar um número que ninguém consegue conferir.
+ */
+export const GOOGLE_REVIEWS = {
+  /** Formato do schema.org — ponto decimal. */
+  ratingValue: '5.0',
+  reviewCount: '15',
+  /** Formato pt-BR, para a tela. */
+  ratingDisplay: '5,0',
+  /**
+   * Perfil da loja no Google, por CID — a única forma de link que veio do próprio
+   * Google (o link curto do perfil resolve para o feature ID 0x9bdf66871be8a1:
+   * 0x42ffd6f49e486b21, e 0x42ffd6f49e486b21 = 4827813671680371489).
+   *
+   * É o que torna a nota conferível: sem ele, "5,0★" é mais uma afirmação sem fonte,
+   * que é exatamente o problema que este arquivo existe para não repetir. NÃO trocar
+   * por Place ID derivado nem por URL de busca do Maps — `CONTACT.mapsUrl` é busca por
+   * endereço, cai no mapa e não no perfil, então não serve aqui.
+   */
+  profileUrl: 'https://maps.google.com/?cid=4827813671680371489',
+  /** Data em que as avaliações foram lidas no perfil. É o que ancora os "há N semanas". */
+  snapshotDate: '10/08/2026',
+  /**
+   * Os três depoimentos exibidos na home, escolhidos para cobrir promessas
+   * DIFERENTES do site (rapidez, canal de WhatsApp e preço, box blindex) em vez de
+   * repetir o mesmo elogio três vezes.
+   *
+   * `text` é copiado como o cliente escreveu, incluindo pontuação e concordância:
+   * corrigir a fala de alguém é reescrevê-la, e aí ela deixa de ser dele. `age` é o
+   * "há quanto tempo" que o Google exibia na data do snapshot — por isso a data do
+   * snapshot fica visível na seção, senão o rótulo envelhece calado.
+   */
+  featured: [
+    {
+      author: 'Marcos Leite',
+      age: 'há 1 semana',
+      text: 'Excelente atendimento. Foram muito solícitos e educados. Resolveram meu problema no mesmo dia. Eu indico!',
+    },
+    {
+      author: 'Daniel Santos',
+      age: 'há 3 semanas',
+      text: 'Atendimento excelente e rápido, ótimo suporte pelo whatsapp, instalação fácil e preço bom para os padrões do mercado. Recomendo demais',
+    },
+    {
+      author: 'Luciene Lima',
+      age: 'há 23 semanas',
+      text: 'Gostei muito do serviço da loja. Blindex do box do banheiro muito bem instalado. Ótimo custo benefício. Indico!',
+    },
+  ],
 };
 
 export const SERVICES = [

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,18 @@ import { Image } from 'astro:assets';
 import Base from '../layouts/Base.astro';
 import lojaFrente from '../assets/loja-verly-realengo.png';
 import QuoteForm from '../components/QuoteForm.astro';
-import { CONTACT } from '../data/site';
+import { CONTACT, GOOGLE_REVIEWS } from '../data/site';
+
+// Iniciais do avatar DERIVADAS do nome do autor. Antes eram três strings digitadas à
+// mão ao lado de três nomes inventados; com nomes reais, digitar de novo só cria uma
+// segunda fonte de verdade para alguém desencontrar depois.
+const initials = (name: string): string =>
+  name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part.charAt(0).toUpperCase())
+    .join('');
 ---
 
 <Base
@@ -72,7 +83,14 @@ import { CONTACT } from '../data/site';
                     </div>
                     <div class="trust-badge">
                         <div class="trust-badge-icon"><Icon name="star" /></div>
-                        <div class="trust-badge-text">4.8★ (127 avaliações)</div>
+                        {/* Nota sem contagem, e com a fonte clicável: a diferença entre uma
+                            estrela que o visitante acredita e uma que ele confere é o link. A
+                            contagem real (15) fica só no aggregateRating — ver GOOGLE_REVIEWS. */}
+                        <div class="trust-badge-text">
+                            <a href={GOOGLE_REVIEWS.profileUrl} target="_blank" rel="noopener noreferrer">
+                                {GOOGLE_REVIEWS.ratingDisplay}★ no Google
+                            </a>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -245,61 +263,34 @@ import { CONTACT } from '../data/site';
     <section id="depoimentos" class="section">
         <div class="container">
             <h2 class="section-title">O Que Nossos Clientes Dizem</h2>
+            {/* Os três cartões eram texto de escritório assinado por gente que não existe.
+                Agora saem de GOOGLE_REVIEWS.featured — avaliações do perfil da loja, copiadas
+                na íntegra. O subtítulo trocou "mais de 127 projetos" pela procedência: ali o
+                127 era a contagem falsa de avaliações reaproveitada como contagem de obras. O
+                que o visitante pode conferir não é quantos, é onde as falas estão publicadas —
+                e em que data foram lidas, senão os "há N semanas" envelhecem calados. */}
             <p class="section-subtitle">
-                Mais de 127 projetos realizados na Zona Oeste com excelência
+                Avaliações publicadas por clientes
+                <a href={GOOGLE_REVIEWS.profileUrl} target="_blank" rel="noopener noreferrer">no perfil do Google da loja</a>,
+                reproduzidas aqui na íntegra — como estavam em {GOOGLE_REVIEWS.snapshotDate}
             </p>
             <div class="testimonials-grid">
+                {GOOGLE_REVIEWS.featured.map((review) => (
                 <div class="testimonial-card">
                     <div class="testimonial-quote">"</div>
                     <div class="testimonial-content">
-                        <p class="testimonial-text">
-                            Instalaram o box do meu banheiro em menos de 3 horas. Ficou perfeito! 
-                            Equipe profissional e atenciosa. Super recomendo!
-                        </p>
+                        <p class="testimonial-text">{review.text}</p>
                         <div class="testimonial-author">
-                            <div class="testimonial-avatar">MC</div>
+                            <div class="testimonial-avatar">{initials(review.author)}</div>
                             <div class="testimonial-info">
-                                <h3>Mariana Costa</h3>
-                                <p>Barra da Tijuca</p>
+                                <h3>{review.author}</h3>
+                                <p>{review.age}</p>
                                 <div class="testimonial-stars">★★★★★</div>
                             </div>
                         </div>
                     </div>
                 </div>
-                <div class="testimonial-card">
-                    <div class="testimonial-quote">"</div>
-                    <div class="testimonial-content">
-                        <p class="testimonial-text">
-                            Excelente custo-benefício! Fizeram a sacada de vidro do meu apartamento 
-                            com qualidade e no prazo combinado. Muito satisfeito!
-                        </p>
-                        <div class="testimonial-author">
-                            <div class="testimonial-avatar">RS</div>
-                            <div class="testimonial-info">
-                                <h3>Ricardo Santos</h3>
-                                <p>Recreio dos Bandeirantes</p>
-                                <div class="testimonial-stars">★★★★★</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="testimonial-card">
-                    <div class="testimonial-quote">"</div>
-                    <div class="testimonial-content">
-                        <p class="testimonial-text">
-                            Atendimento rápido e orçamento justo. Instalaram espelhos na minha loja 
-                            e ficou lindo. Já indiquei para vários amigos!
-                        </p>
-                        <div class="testimonial-author">
-                            <div class="testimonial-avatar">PL</div>
-                            <div class="testimonial-info">
-                                <h3>Paula Lima</h3>
-                                <p>Jacarepaguá</p>
-                                <div class="testimonial-stars">★★★★★</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                ))}
             </div>
         </div>
     </section>

--- a/src/styles/index-inline.css
+++ b/src/styles/index-inline.css
@@ -356,6 +356,25 @@
             line-height: 1.3;
         }
 
+        /* O selo de avaliação leva ao perfil no Google — é o que deixa a nota conferível.
+           Herdar a cor é obrigatório: o azul default de link cairia sobre o gradiente azul
+           do hero e sumiria. O sublinhado fica porque, sem cor própria, é o único sinal de
+           que ali há um link. */
+        .trust-badge-text a {
+            color: inherit;
+            text-decoration: underline;
+            text-underline-offset: 2px;
+        }
+
+        /* Mesma ideia no subtítulo dos depoimentos, mas sobre fundo branco: aqui o azul da
+           marca (--primary, 6.66:1 no branco, o mesmo par que o gate de contraste já
+           verifica) diz "link" sem depender só do sublinhado. */
+        .section-subtitle a {
+            color: var(--primary);
+            text-decoration: underline;
+            text-underline-offset: 2px;
+        }
+
         /* Services Section */
         /* Colunas explícitas por breakpoint em vez de auto-fit. Com minmax(280px) o
            1440 dava 4 colunas para 6 cartões — 4+2, e o vazio à direita do tamanho de


### PR DESCRIPTION
The site sold `4.8★ (127 avaliações)` and "mais de 127 projetos". Neither number
has a source — both came from the old site and survived every refactor, including
into `aggregateRating`, where structured data that contradicts the Google Business
Profile costs the whole rich result and not just the inflated star.
`LocalBusinessSchema.astro:14` has carried that as an open risk since 07/08,
explicitly waiting for the real reviews. They arrived: **15 reviews, all five
stars**.

The rating goes on screen; **the count does not** (owner's decision). `15` survives
in `reviewCount` because schema.org requires the field inside `aggregateRating` —
it is in the source, never in the UI.

## Before / after

| file:line | before | after |
|---|---|---|
| `src/pages/index.astro:75` | `4.8★ (127 avaliações)` | `5,0★ no Google`, linking to the shop's Google profile |
| `src/pages/index.astro:249` | "Mais de 127 projetos realizados na Zona Oeste com excelência" | "Avaliações publicadas por clientes **no perfil do Google da loja**, reproduzidas aqui na íntegra — como estavam em 10/08/2026" |
| `src/components/Footer.astro:35` | `4.8★ (127 avaliações)` | `5,0★ no Google` (plain text, see *Analytics* below) |
| `src/components/QuoteForm.astro:80` | "Mais de 127 projetos realizados com sucesso" | "Mais de 10 anos de experiência, com loja física em Realengo" |
| `src/components/LocalBusinessSchema.astro:66` | `ratingValue: '4.8', reviewCount: '127'` | `ratingValue: GOOGLE_REVIEWS.ratingValue` (`5.0`), `reviewCount: …` (`15`) |
| `src/components/LocalBusinessSchema.astro:14` | comment logging the risk as OPEN | comment recording it as CLOSED on 10/08, why the count lives only in the schema, and where the numbers come from |
| `src/data/site.ts:37-38` | `lat: -22.8814, lng: -43.4251` | `lat: -22.8855432, lng: -43.4305539` — the old pair was ~700 m off and was published in the `geo` of every `LocalBusiness` |

Rating, count, snapshot date, profile URL and the three quoted reviews now live in
one place — `GOOGLE_REVIEWS` in `src/data/site.ts` — consumed by the badge, the
footer, the testimonials and the schema. Three copies of the same number in three
files is how `4.8 / 127` outlived the site that invented it.

## The three testimonials

Mariana Costa, Ricardo Santos and Paula Lima did not exist. Replaced by three real
reviews, **quoted verbatim** — the customer's punctuation and grammar untouched,
because correcting someone's words is rewriting them. Chosen to back *different*
promises rather than repeat one compliment three times:

| review | what it backs |
|---|---|
| **Marcos Leite** (há 1 semana) — "…Resolveram meu problema no mesmo dia. Eu indico!" | the speed promise the hero makes ("Orçamento em até 2 Horas"), and it is the most recent one |
| **Daniel Santos** (há 3 semanas) — "…ótimo suporte pelo whatsapp, instalação fácil e preço bom…" | the WhatsApp channel every CTA points at, plus price |
| **Luciene Lima** (há 23 semanas) — "Blindex do box do banheiro muito bem instalado. Ótimo custo benefício." | box blindex, the lead product, installed |

The two Google fields that make a review checkable are kept: **name** and **how
long ago**. Because "há 23 semanas" would silently rot on a static page, the
section states the date the profile was read (10/08/2026), which is what those
labels are relative to. Avatar initials are now *derived* from the author name
instead of typed by hand next to it.

Not used: Aline Freitas, Daniele Reis, DANIEL RASTELY (each overlaps a promise
already covered), and the nine text-less five-star reviews — they count toward the
total, they are not testimonials.

## Why "127 projetos" did not become another number

That 127 is the fake review count recycled as a job count; there is no record of
how many jobs were done, so any replacement number would repeat the original sin
with a different digit. What replaced it is what a visitor can verify: **ten years
in business** (already claimed in the footer), and a **physical shop in Realengo**
with a real address and the real storefront photo already in the hero. In the
testimonials section the claim of volume was dropped entirely in favour of
provenance — where the quotes are published, and when they were read.

## Verifiability

Both the badge and the testimonials section link to
`https://maps.google.com/?cid=4827813671680371489` — the CID from the shop's own
Google short link, not a derived Place ID and not `CONTACT.mapsUrl`, which is a
Maps *search* by address and lands on the map rather than the profile.

## Measurements

`npm run build` green, including `check:contrast` (13 pairs + the CTA/hero
luminance separation). The two new links needed CSS to stay legible and it reuses
verified pairs: the hero badge link inherits white on the blue gradient (the
browser default blue would vanish there), the subtitle link uses `--primary`, which
is the `#0f5f9e`-on-white pair the gate already checks at 6.66:1. Underlines on
both, so the link is not signalled by colour alone.

Puppeteer against `npm run preview`, at 1440x900 and 390x844, on `/`,
`/realengo.html`, `/blog.html` and `/obrigado.html` — 8 page loads, all green:

- **`127`, `4.8`, `4,8` — 0 occurrences** in rendered text on every page/viewport. The strings still match `dist/*.html` only inside SVG path coordinates (`…-127.62…`, `…4.7 4.8 4.6…`), never as text.
- **Mariana Costa / Ricardo Santos / Paula Lima — 0 occurrences** anywhere.
- **The count never appears in visible text** (asserted, not eyeballed).
- **`JSON.parse` of the `application/ld+json` succeeds** on every page that has one; `LocalBusiness` carries `ratingValue: "5.0"`, `reviewCount: "15"`, `geo: -22.8855432, -43.4305539`. `realengo.html` keeps its pre-existing no-`aggregateRating` parity; `blog.html` and `obrigado.html` keep `schema={false}`.
- **Trust badges still whole in the fold**, no regression on #56: home **5/5** (desktop bottoms 668 ≤ 900; mobile 581-695 ≤ 844), neighbourhood **4/4** (629 ≤ 900; 544 ≤ 844). The rating badge keeps its `order: -1` first position, and the new label is shorter than the one it replaced.
- Rendered cards read: `ML / Marcos Leite / há 1 semana`, `DS / Daniel Santos / há 3 semanas`, `LL / Luciene Lima / há 23 semanas`, each with the verbatim text.

## Scope notes

- Nothing under `public/js/` or `docs/` was touched. `README.md:316-319` was, because it restates the same two fabricated numbers as site copy.
- **Analytics deliberately untouched.** The two new links live in `.trust-badge-text` and `.section-subtitle`, which no listener in `app.js` selects, so no new event and no collision with the instrumentation PR in flight. The footer rating line was left as plain text on purpose: `.footer a` is auto-bound to `navigation_click`, and a link there would have changed that event surface. Tracking those outbound profile clicks is a follow-up for whoever owns the taxonomy.
- Pre-existing, not fixed here: the ten neighbourhood pages with `hasRating: true` emit `aggregateRating` while showing no rating anywhere on the page — Google wants the rating visible on the page that claims it. Worth a separate decision, since the fix is either a visible badge on those pages or dropping the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
