### PR TITLE
feat(social proof): show the rating on the neighborhood pages that declare it

### DIFF
--- a/src/components/LocalBusinessSchema.astro
+++ b/src/components/LocalBusinessSchema.astro
@@ -5,7 +5,8 @@ import neighborhoods from '../data/neighborhoods.json';
 interface Props {
   /** URL absoluta da imagem — mesma do og:image, para não divergirem */
   image?: string;
-  /** paridade com o site atual: realengo.html não tem aggregateRating hoje */
+  /** emite aggregateRating. Era false em realengo por paridade com o site antigo;
+      agora as 11 páginas de bairro exibem a nota na tela, então todas declaram. */
   includeRating?: boolean;
 }
 const { includeRating = true, image } = Astro.props;

--- a/src/data/neighborhoods.json
+++ b/src/data/neighborhoods.json
@@ -292,7 +292,7 @@
     "ogDescription": null,
     "title": "Vidraçaria em Realengo | Verly Vidraçaria",
     "ogImage": null,
-    "hasRating": false,
+    "hasRating": true,
     "keywords": "vidraçaria Realengo, vidros temperados Realengo, box blindex Realengo, cortina de vidro Realengo, vidros Zona Oeste",
     "robots": null
   },

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,7 +1,7 @@
 ---
 import Icon from '../components/Icon.astro';
 import Base from '../layouts/Base.astro';
-import { CONTACT, SITE_URL } from '../data/site';
+import { CONTACT, SITE_URL, GOOGLE_REVIEWS } from '../data/site';
 import QuoteForm from '../components/QuoteForm.astro';
 import { Image } from 'astro:assets';
 import lojaFrente from '../assets/loja-verly-realengo.png';
@@ -77,10 +77,10 @@ const faqSchema =
             <div class="trust-badge-icon"><Icon name="clock" /></div>
             <div class="trust-badge-text">Resposta em 2h</div>
           </div>
-                    <div class="trust-badge">
-                        <div class="trust-badge-icon"><Icon name="credit-card" /></div>
-                        <div class="trust-badge-text">Parcelamos em até 12x</div>
-                    </div>
+          <div class="trust-badge">
+            <div class="trust-badge-icon"><Icon name="credit-card" /></div>
+            <div class="trust-badge-text">Parcelamos em até 12x</div>
+          </div>
           <div class="trust-badge">
             <div class="trust-badge-icon"><Icon name="tools" /></div>
             <div class="trust-badge-text">Instalação Profissional</div>
@@ -88,6 +88,19 @@ const faqSchema =
           <div class="trust-badge">
             <div class="trust-badge-icon"><Icon name="shield-alt" /></div>
             <div class="trust-badge-text">Garantia de Qualidade</div>
+          </div>
+          {/* Quinto filho de propósito: .trust-badges > :nth-child(5) tem order:-1, então
+              a nota assume a primeira posição sem CSS novo — mesmo arranjo da home.
+              E ela precisa estar AQUI, visível: estas páginas já declaravam
+              aggregateRating no schema sem mostrar nota nenhuma na tela, que é
+              justamente o que o Google não aceita. */}
+          <div class="trust-badge">
+            <div class="trust-badge-icon"><Icon name="star" /></div>
+            <div class="trust-badge-text">
+              <a href={GOOGLE_REVIEWS.profileUrl} target="_blank" rel="noopener noreferrer">
+                {GOOGLE_REVIEWS.ratingDisplay}★ no Google
+              </a>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Follow-up to #60, on the pages it did not reach.

## Why

Ten of the eleven neighborhood pages emitted `aggregateRating` in their LocalBusiness schema while showing **no rating on screen** — their four badges were response time, instalments, installation and warranty. Google asks that marked-up content be visible on the page that declares it, so those ten sat in the same class of risk #60 closes on the home — on exactly the pages that exist for local search.

## What changed

| | before | after |
|---|---|---|
| badges on neighborhood pages | 4, no rating | **5**, rating first |
| pages declaring `aggregateRating` without showing it | **10** | **0** |
| `realengo` `hasRating` | `false`, kept from the old site for migration parity | `true` — it now shows the rating like every sibling, so it declares one too |
| new CSS | — | **none**; `.trust-badges > :nth-child(5)` already carries `order:-1`, so the rating takes first place exactly as on the home |

The parity note in `LocalBusinessSchema.astro` said realengo has no `aggregateRating`; it was updated rather than left to rot.

## Measured on the built output

`realengo`, `freguesia-de-jacarepagua`, `barra-da-tijuca` and the home, at 1440 / 430 / 390 / 360:

| check | result |
|---|---|
| badges inside the fold | **5/5** at every width, including 360 |
| first badge | `5,0★ no Google` in every viewport |
| hero CTAs still in the fold | yes — #56's tuning is not regressed |
| `aggregateRating` | `5.0` / `15`, with the rating now visible on the page |
| `geo` | `-22.8855432,-43.4305539` |
| build + contrast gate | pass, 16 pages |

🤖 Generated with [Claude Code](https://claude.com/claude-code)