### PR TITLE
fix(cta): ration the green, and let the CI see the contrast it was missing

### DIFF
--- a/public/js/whatsapp-cta.js
+++ b/public/js/whatsapp-cta.js
@@ -223,8 +223,8 @@ const WhatsAppCTA = {
         stickyBar.innerHTML = `
             <div class="sticky-cta-content">
                 <div class="sticky-cta-text">
-                    <strong>🎉 Orçamento Grátis em 2 Horas!</strong>
-                    <span>Fale com nossos especialistas agora</span>
+                    <strong>Ficou com dúvida?</strong>
+                    <span>Chame no WhatsApp e a gente responde</span>
                 </div>
                 <a href="${this.waLink(this.messages.urgente)}"
                    class="sticky-cta-button"

--- a/scripts/check-contrast.mjs
+++ b/scripts/check-contrast.mjs
@@ -6,7 +6,13 @@
 // desatualizar.
 import { readFileSync } from 'node:fs';
 
-const CSS = readFileSync(new URL('../src/styles/index-inline.css', import.meta.url), 'utf8');
+// Os tokens vivem no index-inline.css; whatsapp-cta.css entra na leitura porque os
+// componentes de lá (barra sticky, botão do card de serviço) fixavam o verde em hex e
+// escapavam desta verificação por isso mesmo — o rótulo saía com 1,98:1 e o CI passava
+// verde. Agora eles consomem os tokens, e um hex solto neles é pego abaixo.
+const CSS = ['../src/styles/index-inline.css', '../src/styles/whatsapp-cta.css']
+  .map((path) => readFileSync(new URL(path, import.meta.url), 'utf8'))
+  .join('\n');
 
 const tokens = Object.fromEntries(
   [...CSS.matchAll(/--([a-z-]+):\s*(#[0-9a-fA-F]{6})/g)].map((m) => [m[1], m[2]])
@@ -37,6 +43,13 @@ const PAIRS = [
   ['Estrelas de avaliação', 'star', 'white', false],
   ['Marca — nome no cabeçalho', 'primary', 'white', false],
   ['Marca — descritor "Vidraçaria"', 'secondary', 'white', false],
+  // Componentes de whatsapp-cta.css. Repetem pares já cobertos acima de propósito: o
+  // que interessa aqui é o relatório NOMEAR o componente, porque foram estes dois que
+  // erraram na prática.
+  ['Barra sticky — botão', 'whatsapp-text', 'whatsapp', false],
+  ['Barra sticky — texto de apoio', 'gray', 'white', false],
+  ['Card de serviço — botão em repouso', 'dark', 'white', false],
+  ['Card de serviço — botão em hover', 'whatsapp-text', 'whatsapp', false],
 ];
 
 const MIN = { normal: 4.5, large: 3.0 };
@@ -66,6 +79,27 @@ console.log(
   `\n${pop >= POP_MIN ? '✓' : '✗'} Separação de luminância CTA vs hero: ${pop.toFixed(2)}:1 (mínimo ${POP_MIN})`
 );
 if (pop < POP_MIN) failed++;
+
+// A tabela acima só enxerga o que passa pelos tokens. O defeito real foi outro: dois
+// componentes escreveram o verde da marca em hex, então nenhum par aqui os descrevia e o
+// CI passava verde com um rótulo de 1,98:1 no ar. Este guard fecha essa porta.
+const WHATSAPP_LITERALS = /#25d366|#128c7e/gi;
+const COMPONENTES = readFileSync(new URL('../src/styles/whatsapp-cta.css', import.meta.url), 'utf8')
+  // Sem os comentários: eles CITAM os hex antigos para registrar por que saíram, e um
+  // guard que proíbe explicar o defeito empurra a explicação para fora do arquivo.
+  .replace(/\/\*[\s\S]*?\*\//g, '');
+const literais = [...COMPONENTES.matchAll(WHATSAPP_LITERALS)].map((m) => m[0]);
+// rgba() de sombra é aceitável — cor de sombra não é par texto/fundo. Hex é que não.
+if (literais.length) {
+  console.error(
+    `\n✗ whatsapp-cta.css escreve o verde da marca em hex (${[...new Set(literais)].join(', ')}).` +
+      `\n  Use var(--whatsapp) / var(--whatsapp-dark) com var(--whatsapp-text), senão o par` +
+      `\n  texto/fundo fica fora desta verificação — foi assim que 1,98:1 chegou à produção.`
+  );
+  failed++;
+} else {
+  console.log('\n✓ Nenhum verde de marca em hex nos componentes de CTA');
+}
 
 if (failed) {
   console.error(`\n${failed} verificação(ões) de contraste falharam.`);

--- a/src/styles/whatsapp-cta.css
+++ b/src/styles/whatsapp-cta.css
@@ -7,22 +7,32 @@
    STICKY CTA BAR (aparece após scroll)
    ============================================================================ */
 
-/* Começa onde o cabeçalho termina. Com `top: 0` a barra ficava ATRÁS do header
-   (fixed, z-index 1000, opaco): no desktop desaparecia inteira e no mobile sobrava
-   só o botão, sem a frase que justifica o clique. A altura vem do token definido
-   junto do .header, então não há um segundo número para desencontrar. */
+/* Barra embaixo, e não sob o cabeçalho.
+   No topo ela empilhava com o header: os dois juntos comiam 144px de uma tela de 844,
+   17% coberto por moldura antes de qualquer conteúdo. Embaixo não empilha com nada e
+   cai na área do polegar.
+   De quebra, mata uma classe de bug por construção. A barra nasceu com `top: 0` e
+   ficava ATRÁS do header (fixed, z-index 1000, opaco); a correção seguinte a ancorou
+   em `--header-height`, o que resolvia a sobreposição e mantinha as duas molduras.
+   Naquela borda não há nada fixo além do flutuante, que já se esconde quando ela sobe.
+
+   Superfície NEUTRA de propósito: a barra verde inteira punha o verde competindo com o
+   próprio botão dela, e obrigava texto branco sobre verde — 1,98:1 no início do
+   gradiente, reprovando AA por quase três vezes. Agora o verde aparece uma vez, no
+   botão, com texto escuro. */
 .whatsapp-sticky-cta {
     position: fixed;
-    top: var(--header-height);
+    bottom: 0;
     left: 0;
     right: 0;
-    background: linear-gradient(135deg, #25D366 0%, #128C7E 100%);
-    box-shadow: 0 4px 20px rgba(37, 211, 102, 0.3);
+    background: var(--white);
+    border-top: 1px solid #e5e7eb;
+    box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.12);
     padding: 12px 20px;
     z-index: 999;
-    transform: translateY(-100%);
-    /* Escondida também no visibility: só o transform deixaria a sombra verde
-       vazando por baixo do cabeçalho enquanto a barra está recolhida. */
+    transform: translateY(100%);
+    /* Escondida também no visibility: só o transform deixaria a sombra vazando pela
+       borda inferior enquanto a barra está recolhida. */
     visibility: hidden;
     transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), visibility 0.4s;
 }
@@ -44,7 +54,7 @@
 .sticky-cta-text {
     display: flex;
     flex-direction: column;
-    color: white;
+    color: var(--dark);
 }
 
 .sticky-cta-text strong {
@@ -54,28 +64,31 @@
 
 .sticky-cta-text span {
     font-size: 0.875rem;
-    opacity: 0.95;
+    color: var(--gray);
 }
 
+/* Verde OFICIAL com texto escuro (7,40:1). Era verde #25D366 sobre branco, que dá os
+   mesmos 1,98:1 do caso invertido: o rótulo do botão mais clicável da barra era o
+   menos legível dela. */
 .sticky-cta-button {
     display: inline-flex;
     align-items: center;
     gap: 10px;
-    background: white;
-    color: #25D366;
+    background: var(--whatsapp);
+    color: var(--whatsapp-text);
     padding: 12px 24px;
     border-radius: 50px;
     font-weight: 700;
     text-decoration: none;
     transition: all 0.3s ease;
     white-space: nowrap;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow);
 }
 
 .sticky-cta-button:hover {
-    transform: scale(1.05);
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
-    color: #128C7E;
+    background: var(--whatsapp-dark);
+    color: var(--whatsapp-text);
+    box-shadow: var(--shadow-lg);
 }
 
 .sticky-cta-button .icon {
@@ -113,13 +126,23 @@
    SERVICE CARD CTA BUTTONS
    ============================================================================ */
 
+/* Peso secundário, e é decisão de hierarquia com um defeito medido por baixo.
+   Eram seis pílulas verdes sólidas com brilho verde, e o rótulo saía branco sobre
+   #25D366: 1,98:1. Reprova AA por quase três vezes, e a verificação do CI não pegava
+   porque estas duas regras fixavam o hex em vez de usar os tokens.
+   A repetição já é o que chama o olho num card que aparece seis vezes — peso sólido
+   também, não. Com o contorno, a página fica com UM verde sólido (o WhatsApp do hero)
+   e UM âmbar sólido (o orçamento), que é a hierarquia que a paleta v2 desenhou.
+   Se `whatsapp_click` com `context` começando em `service-` cair depois disso, é uma
+   classe para voltar — e agora dá para medir, porque os eventos passaram a chegar. */
 .service-whatsapp-cta {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 8px;
-    background: linear-gradient(135deg, #25D366 0%, #128C7E 100%);
-    color: white;
+    background: var(--white);
+    color: var(--dark);
+    border: 2px solid var(--whatsapp);
     padding: 12px 24px;
     border-radius: 50px;
     text-decoration: none;
@@ -127,17 +150,25 @@
     font-size: 0.95rem;
     margin-top: 15px;
     transition: all 0.3s ease;
-    box-shadow: 0 4px 15px rgba(37, 211, 102, 0.3);
 }
 
 .service-whatsapp-cta:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 8px 25px rgba(37, 211, 102, 0.4);
-    color: white;
+    background: var(--whatsapp);
+    color: var(--whatsapp-text);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow);
 }
 
+/* O glifo carrega o verde no estado de repouso — é ele que diz "WhatsApp" sem o botão
+   precisar do preenchimento inteiro. No hover o fundo vira verde, então o ícone
+   acompanha o texto escuro. */
 .service-whatsapp-cta .icon {
     font-size: 1.2rem;
+    color: var(--whatsapp);
+}
+
+.service-whatsapp-cta:hover .icon {
+    color: var(--whatsapp-text);
 }
 
 /* Ajustar service-card para incluir botão */
@@ -159,14 +190,15 @@
     z-index: 1000;
 }
 
-/* Tooltip do botão flutuante */
+/* Tooltip do botão flutuante. Texto escuro sobre o verde oficial (7,40:1); era branco
+   sobre #25D366, os mesmos 1,98:1 dos botões de card. */
 .whatsapp-float-tooltip {
     position: absolute;
     right: 75px;
     top: 50%;
     transform: translateY(-50%) translateX(10px);
-    background: #25D366;
-    color: white;
+    background: var(--whatsapp);
+    color: var(--whatsapp-text);
     padding: 8px 16px;
     border-radius: 8px;
     font-size: 14px;
@@ -186,7 +218,7 @@
     top: 50%;
     transform: translateY(-50%);
     border: 8px solid transparent;
-    border-left-color: #25D366;
+    border-left-color: var(--whatsapp);
 }
 
 .whatsapp-float-tooltip.visible {
@@ -237,94 +269,23 @@
 }
 
 /* ============================================================================
-   HERO CTA IMPROVEMENTS
+   CSS MORTO REMOVIDO — 96 linhas
+   ============================================================================
+
+   Três blocos saíram daqui, e o motivo de estarem documentados em vez de apenas
+   apagados é que eram esconderijo do mesmo defeito: gradiente verde com texto branco,
+   ou seja 1,98:1, fora do alcance da verificação de contraste.
+
+   - `.hero-cta a[href*="whatsapp"]` + `.hero-cta .btn-secondary`: `.hero-cta` existe
+     (index.astro, [slug].astro), mas o link do hero é `wa.me/...`, que NÃO contém
+     "whatsapp", e nenhum hero tem `.btn-secondary`. O seletor não casava com nada — é
+     por isso que o botão do hero aparece verde chapado, e não em gradiente. Mantê-lo
+     seria deixar armada uma regra que passa a valer no dia em que alguém trocar o
+     href por api.whatsapp.com.
+   - `.contact-whatsapp-cta` e `.quick-response-badge`: as classes não aparecem em
+     nenhum .astro nem em nenhum script de /public. O badge, de quebra, tinha 3,67:1.
+
    ============================================================================ */
-
-/* Melhorar visual do botão WhatsApp no hero */
-.hero-cta a[href*="whatsapp"],
-.hero-cta .btn-secondary {
-    background: linear-gradient(135deg, #25D366 0%, #128C7E 100%);
-    border: none;
-    box-shadow: 0 4px 15px rgba(37, 211, 102, 0.3);
-    position: relative;
-    overflow: hidden;
-}
-
-.hero-cta a[href*="whatsapp"]::before,
-.hero-cta .btn-secondary::before {
-    content: '';
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 0;
-    height: 0;
-    border-radius: 50%;
-    background: rgba(255, 255, 255, 0.2);
-    transform: translate(-50%, -50%);
-    transition: width 0.6s, height 0.6s;
-}
-
-.hero-cta a[href*="whatsapp"]:hover::before,
-.hero-cta .btn-secondary:hover::before {
-    width: 300px;
-    height: 300px;
-}
-
-.hero-cta a[href*="whatsapp"]:hover,
-.hero-cta .btn-secondary:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 8px 25px rgba(37, 211, 102, 0.4);
-}
-
-/* ============================================================================
-   CONTACT SECTION CTA
-   ============================================================================ */
-
-/* Adicionar estilo para CTA na seção de contato */
-.contact-whatsapp-cta {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 12px;
-    background: linear-gradient(135deg, #25D366 0%, #128C7E 100%);
-    color: white;
-    padding: 16px 32px;
-    border-radius: 12px;
-    text-decoration: none;
-    font-weight: 700;
-    font-size: 1.1rem;
-    margin: 20px 0;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 20px rgba(37, 211, 102, 0.3);
-}
-
-.contact-whatsapp-cta:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 8px 30px rgba(37, 211, 102, 0.5);
-    color: white;
-}
-
-.contact-whatsapp-cta i {
-    font-size: 1.5rem;
-}
-
-/* Badge "Resposta Rápida" */
-.quick-response-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    background: rgba(37, 211, 102, 0.15);
-    color: #128C7E;
-    padding: 6px 12px;
-    border-radius: 20px;
-    font-size: 0.85rem;
-    font-weight: 600;
-    margin-top: 8px;
-}
-
-.quick-response-badge i {
-    color: #25D366;
-}
 
 /* ============================================================================
    MOBILE OPTIMIZATIONS
@@ -340,12 +301,6 @@
     .service-whatsapp-cta {
         width: 100%;
     }
-    
-    /* Contact CTA */
-    .contact-whatsapp-cta {
-        font-size: 1rem;
-        padding: 14px 24px;
-    }
 }
 
 /* ============================================================================
@@ -355,7 +310,6 @@
 /* Focus states */
 .sticky-cta-button:focus,
 .service-whatsapp-cta:focus,
-.contact-whatsapp-cta:focus,
 .whatsapp-float:focus {
     outline: 3px solid #FFD700;
     outline-offset: 3px;
@@ -380,7 +334,6 @@
 @media print {
     .whatsapp-sticky-cta,
     .service-whatsapp-cta,
-    .contact-whatsapp-cta,
     .whatsapp-float {
         display: none !important;
     }
@@ -399,13 +352,13 @@
 }
 
 .footer-contact-link:hover {
-    color: #25D366 !important;
+    color: var(--whatsapp) !important;
     transform: translateX(5px);
 }
 
 /* WhatsApp Link no Footer */
 .footer-contact-link.whatsapp-link:hover {
-    color: #25D366 !important;
+    color: var(--whatsapp) !important;
 }
 
 /* Phone Link no Footer */


### PR DESCRIPTION
This started as a judgement call about hierarchy and turned up a measured defect
underneath it.

The six service-card buttons and the sticky bar wrote the brand green as a literal
gradient instead of using the tokens, so they were outside check-contrast.mjs entirely.
Measured:

  white on #25D366 (start of the gradient)      1.98:1   fails AA by ~3x
  white on #128C7E (end of the gradient)        4.14:1   fails
  sticky button: #25D366 text on white          1.98:1   fails
  float tooltip: white on #25D366               1.98:1   fails

Seven buttons whose label was the least readable thing on them, and the CI was green
the whole time. Everything now goes through --whatsapp / --whatsapp-dark with
--whatsapp-text (7.40:1), and the script gained a guard that fails on a brand-green hex
in whatsapp-cta.css — the tokens table could never have caught this, because a
hardcoded component has no pair to look up. Comments are stripped before that scan, so
the file can still explain which hex left and why.

Hierarchy, which is the part that is judgement:
  - The card buttons go to secondary weight (white, green border, green glyph, dark
    label). A card that repeats six times is already found by repetition; it does not
    need solid weight too. The page now has ONE solid green (the hero WhatsApp) and ONE
    solid amber (the quote) — the discipline the v2 palette designed and never applied.
    If whatsapp_click with context starting in `service-` drops, this is one class to
    revert, and it is finally measurable: the events only started reaching GA4
    yesterday.
  - The sticky bar moves to the BOTTOM. At the top it stacked with the fixed header —
    144px of an 844px screen, 17% covered by chrome before any content — and I caught
    it sitting over the text of a testimonial. At the bottom it stacks with nothing, it
    is in thumb reach, and the whole "the header covered the bar" bug class stops
    existing by construction (it had already been fixed twice: top:0, then
    --header-height).
  - Its copy stopped repeating the H1. "🎉 Orçamento Grátis em 2 Horas!" was the
    headline again, one screen lower, with an emoji; it is "Ficou com dúvida? / Chame no
    WhatsApp e a gente responde" now — a different offer from the amber CTA instead of a
    louder copy of it.

Also removes 90 lines of dead CSS, and they are documented in place rather than just
deleted, because they were hiding the same defect:
  - `.hero-cta a[href*="whatsapp"]` never matched anything. `.hero-cta` exists, but the
    hero link is `wa.me/...`, which does not contain "whatsapp", and no hero has
    `.btn-secondary`. That is why the hero button renders flat green and not a gradient.
    Leaving it would arm a rule that starts applying the day someone switches the href
    to api.whatsapp.com.
  - `.contact-whatsapp-cta` and `.quick-response-badge` appear in no .astro and no
    /public script. The badge also measured 3.67:1.

Verified in an emulated iPhone (390x844) against the built preview: bar anchored at the
bottom (top 785 of 844, height 59), active at 44% scroll, float hidden while it is up,
6 card buttons at white background with #1f2937 label.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

**Base is `main`.** Independent of #63 and #64.

## What to look at before merging
The card buttons going from solid to outline is the one call here that is taste plus
theory, not measurement. Everything else is a contrast failure or dead code. If you want
the loud version back with the contrast fixed, say so and it is a three-line diff:
solid `var(--whatsapp)` background with `var(--whatsapp-text)` label, which measures
7.40:1 — the six buttons just stay loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)