### PR TITLE
feat(form): ask for a name and a WhatsApp, and let the rest be optional

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -418,10 +418,6 @@ function validateField(field) {
             errorMessage = 'E-mail inválido';
         }
     }
-    else if (fieldId === 'neighborhood' && field.value === '') {
-        isValid = false;
-        errorMessage = 'Selecione seu bairro';
-    }
     
     // Update UI based on validation
     if (!isValid) {
@@ -462,23 +458,20 @@ function validateField(field) {
 /**
  * Validate services checkboxes
  */
-function validateServices() {
-    const checkboxes = document.querySelectorAll('input[name="services"]:checked');
-    const errorElement = document.getElementById('servicesError');
-    
-    if (checkboxes.length === 0) {
-        if (errorElement) {
-            errorElement.textContent = 'Selecione pelo menos um serviço';
-        }
-        trackFormInteraction('validation_error', 'services', '', 'Nenhum serviço selecionado');
-        return false;
-    }
-    
-    if (errorElement) {
-        errorElement.textContent = '';
-    }
-    return true;
-}
+/*
+ * `validateServices()` foi removida daqui.
+ *
+ * Ela existia para barrar o envio sem serviço marcado, e o bloco de serviços deixou de
+ * ser obrigatório: eram oito decisões antes do botão, num campo cuja resposta o
+ * atendimento obtém na primeira pergunta da conversa.
+ *
+ * Consequência no analytics, de propósito: `validation_error` com
+ * `field_name = services` para de existir, e `generate_lead` passa a poder sair com
+ * `services` vazio e `services_count: 0`. Isso não é perda de sinal — é o sinal novo:
+ * a fração de leads que não quis detalhar o serviço é exatamente o que dizia se o
+ * campo obrigatório valia a pena, e antes ela era inobservável porque ninguém
+ * conseguia enviar sem responder.
+ */
 
 // ============================================================================
 // SERVIÇOS — CHAVE CURTA E ESTÁVEL
@@ -793,7 +786,6 @@ async function handleFormSubmit(event) {
     if (!validateField(phoneField)) isValid = false;
     if (!validateField(emailField)) isValid = false;
     if (!validateField(neighborhoodField)) isValid = false;
-    if (!validateServices()) isValid = false;
     
     if (!isValid) {
         showAlert('Por favor, corrija os campos destacados em vermelho.', 'error');
@@ -935,12 +927,16 @@ async function handleFormSubmit(event) {
             // Entrega não confirmada: o WhatsApp continua sendo a última rede de
             // segurança, com ou sem fila. Uma mensagem só para os dois modos de falha —
             // a versão curta do antigo `catch` deixava e-mail e observação de fora.
+            // Bairro e serviços viraram opcionais, então as duas linhas passam a ser
+            // condicionais como a do e-mail já era. Sem isso a mensagem chegaria com
+            // "*Bairro:* " e "*Serviços de Interesse:* " vazios — rótulo sem resposta
+            // parece campo perdido no caminho, e é o dono lendo isso no WhatsApp.
             const whatsappMessage = `*Solicitação de Orçamento - Verly Vidraçaria*\n\n` +
                 `*Nome:* ${formData.name}\n` +
                 `*Telefone:* ${phoneDisplay}\n` +
-                `*Bairro:* ${formData.neighborhood}\n` +
+                (formData.neighborhood ? `*Bairro:* ${formData.neighborhood}\n` : '') +
                 (formData.email ? `*E-mail:* ${formData.email}\n` : '') +
-                `*Serviços de Interesse:* ${selectedServices.join(', ')}\n` +
+                (selectedServices.length ? `*Serviços de Interesse:* ${selectedServices.join(', ')}\n` : '') +
                 (messageText ? `*Mensagem:* ${messageText}\n\n` : '\n') +
                 `Enviado através do site verlyvidracaria.com`;
 
@@ -1258,11 +1254,6 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                 });
             }
-        });
-        
-        // Validate services on change
-        document.querySelectorAll('input[name="services"]').forEach(checkbox => {
-            checkbox.addEventListener('change', validateServices);
         });
         
         // Form submission

--- a/src/components/QuoteForm.astro
+++ b/src/components/QuoteForm.astro
@@ -139,15 +139,19 @@ const {
                             <div class="form-help">Opcional, mas nos ajuda a enviar o orçamento</div>
                         </div>
 
+                        {/* Deixou de ser obrigatório. Nas 11 páginas de bairro ele já vem
+                            preenchido, então exigir não custava nada ali — mas na home
+                            custava, e era o terceiro obstáculo antes do envio. Quem atende
+                            pergunta o bairro na primeira frase da conversa; o formulário
+                            não precisa ser o lugar onde isso é decidido. */}
                         <div class="form-group">
                             <label class="form-label" for="neighborhood">
-                                Seu Bairro <span class="required">*</span>
+                                Seu Bairro
                             </label>
-                            <select 
-                                id="neighborhood" 
+                            <select
+                                id="neighborhood"
                                 name="neighborhood"
                                 class="form-control"
-                                required
                             >
                                 <option value="">Selecione seu bairro</option>
                                 {NEIGHBORHOOD_OPTIONS.map((o) => (
@@ -157,10 +161,20 @@ const {
                             <div class="form-error" id="neighborhoodError"></div>
                         </div>
 
-                        <div class="form-group">
-                            <label class="form-label">
-                                Serviços de Interesse <span class="required">*</span>
-                            </label>
+                        {/* Oito checkboxes obrigatórios eram, medindo a seção no celular, o
+                            maior pedaço dos 2.226px de altura do formulário — 2,6 telas — e
+                            o campo mais caro dele: obrigatório, com oito decisões, e o único
+                            cuja resposta o atendimento descobre em uma pergunta.
+                            Fechado num <details>, some da altura de quem não quer detalhar e
+                            continua inteiro para quem quer. Nenhuma opção foi removida: um
+                            <select> de serviço principal encurtaria mais, mas perderia o
+                            pedido de duas coisas ao mesmo tempo, que é comum aqui (box +
+                            espelho no mesmo banheiro).
+                            <details> nativo é o mesmo recurso que o FAQ já usa — zero JS. */}
+                        <details class="form-group services-details">
+                            <summary class="form-label services-summary">
+                                Serviços de interesse <span class="form-optional">(opcional)</span>
+                            </summary>
                             <div class="checkbox-group">
                                 <div class="checkbox-item">
                                     <input type="checkbox" id="service1" name="services" value="Box para Banheiro">
@@ -195,8 +209,7 @@ const {
                                     <label for="service8">Tampos de Mesa</label>
                                 </div>
                             </div>
-                            <div class="form-error" id="servicesError"></div>
-                        </div>
+                        </details>
 
                         <div class="form-group">
                             <label class="form-label" for="message">
@@ -224,8 +237,11 @@ const {
                             <Icon name="clock" /> Responderemos em até 2 horas úteis
                         </p>
 
+                        {/* Não lista mais os campos um a um: com bairro e serviços opcionais,
+                            a lista ficaria falando de dado que talvez nem seja preenchido. A
+                            promessa que importa é a de finalidade, e ela vale para tudo. */}
                         <p class="form-privacy">
-                            <Icon name="shield-alt" /> Usamos seu nome, telefone e bairro apenas para
+                            <Icon name="shield-alt" /> Usamos o que você preencher apenas para
                             responder este pedido de orçamento.
                         </p>
                     </form>

--- a/src/styles/index-inline.css
+++ b/src/styles/index-inline.css
@@ -1207,6 +1207,38 @@
 .faq-item[open] > summary::after { content: '\2212'; }
 .faq-item > p { margin: 0.75rem 0 0; color: #4b5563; }
 
+/* Bloco de serviços do formulário, no mesmo mecanismo do FAQ acima — nativo, sem JS.
+   O `+`/`−` é o que diz que existe conteúdo dobrado ali: sem o affordance, "Serviços
+   de interesse (opcional)" pareceria só um rótulo, e quem QUERIA detalhar não acharia
+   as oito opções. O alvo de toque cobre a linha inteira, não só o texto. */
+.services-details > .services-summary {
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    min-height: 44px;
+    margin-bottom: 0;
+}
+.services-details > .services-summary::-webkit-details-marker { display: none; }
+.services-details > .services-summary::after {
+    content: '+';
+    font-size: 1.5rem;
+    line-height: 1;
+    flex-shrink: 0;
+    color: var(--gray);
+}
+.services-details[open] > .services-summary::after { content: '\2212'; }
+.services-details[open] > .checkbox-group { margin-top: 0.75rem; }
+
+/* "(opcional)" em peso normal: o rótulo é negrito, e a palavra que mais importa aqui é
+   justamente a que dispensa o visitante de responder. */
+.form-optional {
+    font-weight: 400;
+    color: var(--gray);
+}
+
 /* WhatsApp com a cor da própria marca. Antes o botão era outline azul enquanto o
    VERDE estava no botão do formulário — no Brasil verde lê "WhatsApp", então as
    duas cores estavam trocadas de função. */


### PR DESCRIPTION
Two required fields now instead of five. Measured on an emulated iPhone (390x844)
against the built preview:

  #contato section    2226px -> 1806px   (2.6 screens -> 2.1)
  whole home          7186px -> 6790px
  required fields     name, phone, neighborhood, 8 services -> name, phone

What changed, and why each one:

  - Neighborhood is optional. On the 11 neighbourhood pages it arrives pre-filled, so
    requiring it cost nothing there — but on the home it was the third obstacle before
    the button, and whoever answers asks the neighbourhood in the first sentence of the
    conversation anyway.
  - The 8 service checkboxes are optional and collapsed into a native <details>, the
    same mechanism the FAQ already uses. Zero JS. Measuring the section, that block was
    the largest single piece of its height AND the most expensive field in it:
    mandatory, eight decisions, and the one answer a phone call obtains in one question.
    Nothing was removed — a single "main service" <select> would be shorter still, but
    it loses asking for two things at once, which is common here (box plus mirror in the
    same bathroom).
  - validateServices() is gone rather than softened, and the comment in its place says
    what that costs in the reports: `validation_error` with field_name=services stops
    existing, and generate_lead can now carry an empty `services` with
    `services_count: 0`. That is not lost signal, it IS the new signal — the share of
    people who did not want to specify a service is exactly what tells you whether the
    mandatory field was worth it, and it was unobservable before because nobody could
    submit without answering.

Server side checked before shipping, not assumed: LeadDTO has no bean validation at all
and POST /leads has no @Valid, so an empty neighborhood is accepted. Lead completeness
does not drop either — `hasLocationData` (LeadService.java:665) is satisfied by city OR
neighborhood, and app.js always sends city.

Two knock-ons from making the fields optional, both fixed here:
  - The WhatsApp fallback message would have rendered "*Bairro:* " and "*Serviços de
    Interesse:* " with nothing after them. Both lines are conditional now, like the
    e-mail line already was — a label with no answer reads like data lost in transit,
    and it is the owner reading it.
  - The privacy line stopped enumerating fields ("nome, telefone e bairro"), since it
    would be promising about data that may never be filled. The promise that matters is
    the purpose one, and it covers everything.

NOT verified, and it needs you: the successful submit path. I drove the form on the local
preview against the production API and the preflight was refused with
PreflightInvalidStatus — prod only allows https://verlyvidracaria.com and painel., so
localhost cannot reach it and NO test lead was created. What I could verify locally: the
phone mask, that only name and phone block submission, and that the request is fired
with `neighborhood: ""`. The end-to-end proof is one real submission from your phone
after this deploys.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

**Base is `main`.** No file overlap with #63, #64 or #65 — the four merge in any order.

## The call you may want to reverse
Keeping all 8 services instead of collapsing them into a single "main service" select is
the conservative half of this change. A select would take the section under 1600px and
would turn the §5.2 analysis from "contains" into a real partition — but it stops someone
asking for a box and a mirror at once. Say the word and it is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)