### PR TITLE
feat(social proof): publish the reviews customers actually sent

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,13 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+  # As avaliações aprovadas são lidas em tempo de BUILD (src/data/published-reviews.ts),
+  # então sem isto aprovar uma no Telegram não publicaria nada até alguém dar push — e
+  # quem aprova não é quem faz deploy. Uma vez por dia basta: a avaliação já esperou a
+  # moderação, e um build diário custa menos que um webhook do Pi para o GitHub, que
+  # exigiria segredo, endpoint público e um caminho novo para falhar.
+  schedule:
+    - cron: '17 9 * * *'
 
 permissions:
   contents: read

--- a/src/data/published-reviews.ts
+++ b/src/data/published-reviews.ts
@@ -1,0 +1,111 @@
+import { API_BASE } from './site';
+
+/** O que `GET /published-reviews` devolve (PublicReviewDTO do verly-service). */
+export interface PublishedReview {
+  id: number;
+  customerName: string | null;
+  rating: number;
+  comment: string | null;
+  serviceType: string | null;
+  publishedAt: string | null;
+  photoUrls: string[];
+}
+
+/**
+ * Avaliações que o próprio cliente enviou pelo link e o dono aprovou no Telegram.
+ * Lidas em TEMPO DE BUILD, não no navegador, por três motivos:
+ *
+ * 1. Prova social precisa estar no HTML. Buscar no cliente deixaria o depoimento fora
+ *    do que o Google indexa e fora do que aparece antes do JS rodar — e a primeira tela
+ *    é onde a prova trabalha.
+ * 2. Nada de spinner nem salto de layout numa seção acima da dobra em celular.
+ * 3. A LP é estática no GitHub Pages e a API vive no Orange Pi. Uma leitura por deploy
+ *    é uma dependência; uma por visitante seria colocar o Pi no caminho crítico de todo
+ *    acesso ao site.
+ *
+ * O CONTRÁRIO DISSO É O RISCO, e está tratado abaixo: se a leitura pudesse quebrar o
+ * build, o deploy da landing page passaria a depender do Pi estar no ar. Toda falha aqui
+ * devolve lista vazia e o site sai sem a seção — nunca sem o site.
+ */
+export async function fetchPublishedReviews(): Promise<PublishedReview[]> {
+  // O caminho é o nome pós-verly-service#56. Em prod, enquanto #56 não mergear, ele
+  // responde 403 e esta função devolve [] — a seção simplesmente não aparece. Preferi
+  // isso a tentar o nome antigo em seguida: fallback silencioso entre duas versões de
+  // API esconde qual das duas está no ar justamente quando isso importa saber.
+  const url = `${API_BASE}/published-reviews`;
+
+  try {
+    const resposta = await fetch(url, {
+      headers: { accept: 'application/json' },
+      // O build não pode ficar pendurado esperando o Pi.
+      signal: AbortSignal.timeout(8000),
+    });
+
+    if (!resposta.ok) {
+      console.warn(
+        `[reviews] ${url} respondeu ${resposta.status} — o site sai sem a seção de avaliações da Verly.`
+      );
+      return [];
+    }
+
+    const dados: PublishedReview[] = await resposta.json();
+    const comTexto = dados.filter((r) => (r.comment ?? '').trim().length > 0);
+
+    // Foto que não carrega é pior que foto nenhuma: renderiza um retângulo quebrado no
+    // lugar exato onde a página está tentando provar competência. O serviço já dá HEAD
+    // em cada objeto ao receber a avaliação, mas ele confere o BUCKET — o que decide se
+    // o visitante vê a imagem é o host público, que hoje ainda não resolve. Então o
+    // build confere o host público.
+    const verificadas = await Promise.all(
+      comTexto.map(async (review) => ({
+        ...review,
+        photoUrls: await filtrarFotosAlcancaveis(review.photoUrls ?? []),
+      }))
+    );
+
+    const fotos = verificadas.reduce((total, r) => total + r.photoUrls.length, 0);
+    console.log(`[reviews] ${verificadas.length} avaliação(ões) aprovada(s), ${fotos} foto(s) alcançável(is).`);
+    return verificadas;
+  } catch (erro) {
+    console.warn(
+      `[reviews] não deu para ler ${url} (${erro instanceof Error ? erro.message : erro}) — o site sai sem a seção.`
+    );
+    return [];
+  }
+}
+
+async function filtrarFotosAlcancaveis(urls: string[]): Promise<string[]> {
+  const resultados = await Promise.all(
+    urls.map(async (url) => {
+      try {
+        const r = await fetch(url, { method: 'HEAD', signal: AbortSignal.timeout(5000) });
+        if (r.ok) return url;
+        console.warn(`[reviews] foto ignorada (${r.status}): ${url}`);
+        return null;
+      } catch {
+        console.warn(`[reviews] foto ignorada (host não respondeu): ${url}`);
+        return null;
+      }
+    })
+  );
+  return resultados.filter((url): url is string => url !== null);
+}
+
+/** "há 3 semanas", no mesmo formato dos rótulos que vieram do Google. */
+export function idadeRelativa(publishedAt: string | null, agora: Date): string {
+  if (!publishedAt) return '';
+  const data = new Date(publishedAt);
+  if (Number.isNaN(data.getTime())) return '';
+
+  const dias = Math.floor((agora.getTime() - data.getTime()) / 86_400_000);
+  if (dias <= 0) return 'hoje';
+  if (dias === 1) return 'há 1 dia';
+  if (dias < 7) return `há ${dias} dias`;
+
+  const semanas = Math.floor(dias / 7);
+  if (semanas === 1) return 'há 1 semana';
+  if (semanas < 9) return `há ${semanas} semanas`;
+
+  const meses = Math.floor(dias / 30);
+  return meses === 1 ? 'há 1 mês' : `há ${meses} meses`;
+}

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -2,6 +2,14 @@
 
 export const SITE_URL = 'https://verlyvidracaria.com';
 
+/**
+ * Base do verly-service. O formulário de orçamento tem a URL dele literal em
+ * `public/js/app.js` (`LEAD_ENDPOINT`), que é script de /public e não pode importar
+ * daqui — por isso a duplicação existe e fica anotada em vez de escondida. Quem
+ * mudar o host precisa mudar nos dois lugares.
+ */
+export const API_BASE = 'https://api.verlyvidracaria.com/verly-service';
+
 export const ANALYTICS = {
   ga4: 'G-GDQV6C1NWH',
   googleAds: 'AW-17336857529',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,14 @@ import Base from '../layouts/Base.astro';
 import lojaFrente from '../assets/loja-verly-realengo.png';
 import QuoteForm from '../components/QuoteForm.astro';
 import { CONTACT, GOOGLE_REVIEWS } from '../data/site';
+import { fetchPublishedReviews, idadeRelativa } from '../data/published-reviews';
+
+// Lidas no build. Devolve [] em qualquer falha, de propósito: o deploy da LP não pode
+// depender do Orange Pi estar no ar. Ver o comentário longo em published-reviews.ts.
+const verlyReviews = await fetchPublishedReviews();
+// A data do build ancora os "há N semanas" das avaliações da Verly, do mesmo jeito que
+// GOOGLE_REVIEWS.snapshotDate ancora as do Google. Uma página estática não tem "agora".
+const geradoEm = new Date();
 
 // Iniciais do avatar DERIVADAS do nome do autor. Antes eram três strings digitadas à
 // mão ao lado de três nomes inventados; com nomes reais, digitar de novo só cria uma
@@ -269,12 +277,63 @@ const initials = (name: string): string =>
                 127 era a contagem falsa de avaliações reaproveitada como contagem de obras. O
                 que o visitante pode conferir não é quantos, é onde as falas estão publicadas —
                 e em que data foram lidas, senão os "há N semanas" envelhecem calados. */}
+            {/* O subtítulo é condicional porque a procedência mudou de uma fonte para
+                duas. Enquanto só houver as do Google, ele afirma exatamente o que
+                afirmava; com avaliações vindas do link, dizer "publicadas no perfil do
+                Google" passaria a ser falso para parte dos cartões da mesma grade. */}
             <p class="section-subtitle">
-                Avaliações publicadas por clientes
-                <a href={GOOGLE_REVIEWS.profileUrl} target="_blank" rel="noopener noreferrer">no perfil do Google da loja</a>,
-                reproduzidas aqui na íntegra — como estavam em {GOOGLE_REVIEWS.snapshotDate}
+                {verlyReviews.length > 0 ? (
+                    <>
+                        Avaliações de clientes atendidos pela loja, enviadas por eles e
+                        reproduzidas na íntegra. As três últimas vêm
+                        <a href={GOOGLE_REVIEWS.profileUrl} target="_blank" rel="noopener noreferrer">do perfil do Google</a>,
+                        como estavam em {GOOGLE_REVIEWS.snapshotDate}
+                    </>
+                ) : (
+                    <>
+                        Avaliações publicadas por clientes
+                        <a href={GOOGLE_REVIEWS.profileUrl} target="_blank" rel="noopener noreferrer">no perfil do Google da loja</a>,
+                        reproduzidas aqui na íntegra — como estavam em {GOOGLE_REVIEWS.snapshotDate}
+                    </>
+                )}
             </p>
+            {/* As da Verly vêm primeiro: são as únicas que podem trazer FOTO do serviço
+                instalado, e foto do resultado é o que a página inteira não tem para
+                mostrar. Ficam na mesma grade para não sugerir duas categorias de
+                cliente. */}
             <div class="testimonials-grid">
+                {verlyReviews.map((review) => (
+                <div class="testimonial-card">
+                    <div class="testimonial-quote">"</div>
+                    <div class="testimonial-content">
+                        <p class="testimonial-text">{review.comment}</p>
+                        {review.photoUrls.length > 0 && (
+                            <ul class="testimonial-photos">
+                                {review.photoUrls.map((url) => (
+                                    <li>
+                                        {/* Não passa por astro:assets: o arquivo mora no
+                                            Garage e não na árvore do repo, então não há
+                                            o que otimizar em tempo de build. `loading`
+                                            e `decoding` porque a seção fica abaixo da
+                                            dobra, e aspect-ratio no CSS porque as
+                                            dimensões só o arquivo conhece — sem ela, a
+                                            imagem empurraria o texto ao carregar. */}
+                                        <img src={url} alt={`Serviço realizado pela Verly${review.serviceType ? ` — ${review.serviceType}` : ''}`} loading="lazy" decoding="async" />
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                        <div class="testimonial-author">
+                            <div class="testimonial-avatar">{initials(review.customerName ?? 'Cliente')}</div>
+                            <div class="testimonial-info">
+                                <h3>{review.customerName ?? 'Cliente Verly'}</h3>
+                                <p>{[idadeRelativa(review.publishedAt, geradoEm), review.serviceType].filter(Boolean).join(' · ')}</p>
+                                <div class="testimonial-stars">{'★'.repeat(review.rating)}</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                ))}
                 {GOOGLE_REVIEWS.featured.map((review) => (
                 <div class="testimonial-card">
                     <div class="testimonial-quote">"</div>

--- a/src/styles/index-inline.css
+++ b/src/styles/index-inline.css
@@ -511,6 +511,30 @@
             line-height: 1.8;
         }
 
+        /* Fotos que o próprio cliente mandou junto da avaliação. Só as avaliações vindas
+           do link têm isso — são as primeiras imagens de serviço INSTALADO do site.
+           `aspect-ratio` fixo com `object-fit: cover` porque a dimensão real só o
+           arquivo conhece: sem reservar a caixa, cada foto empurraria o depoimento para
+           baixo ao terminar de carregar, e isso acontece exatamente enquanto a pessoa
+           está lendo. */
+        .testimonial-photos {
+            list-style: none;
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+            gap: 0.5rem;
+            margin: 0 0 1.25rem;
+            padding: 0;
+        }
+
+        .testimonial-photos img {
+            width: 100%;
+            aspect-ratio: 4 / 3;
+            object-fit: cover;
+            border-radius: 8px;
+            display: block;
+            background: var(--light-gray);
+        }
+
         .testimonial-author {
             display: flex;
             align-items: center;


### PR DESCRIPTION
The submission side shipped in #63 and the moderation side shipped in verly-service#53,
so an approved review had nowhere to go. This is the display side: the testimonials
section now shows what customers sent through the link, with their photos, above the
three from the Google profile.

Read at BUILD time, not in the browser, and the reason is the ranking of three things:
social proof has to be in the HTML (a client fetch keeps it out of what Google indexes
and out of what renders before JS), a section above the fold on mobile must not shift
layout, and the landing page is static on GitHub Pages while the API lives on an Orange
Pi — one read per deploy is a dependency, one read per visitor would put the Pi in the
critical path of every visit.

That trade has an obvious failure mode, and it is handled rather than hoped about: if the
fetch could break the build, the landing page deploy would start depending on the Pi
being up. Every failure path — non-2xx, timeout at 8s, malformed JSON, DNS — returns an
empty list, logs a warning in the build output, and the site ships without the section.
Verified both ways: against production it logs 403 and builds 16 pages; against a stub
serving the real DTO shape it renders 5 cards, 3 photos, "há 2 dias · Box para Banheiro"
and four stars for the four-star review.

Decisions that are not obvious from the diff:

  - Photos are HEAD-checked at build time and silently dropped if the public host does
    not answer. The service already HEADs each object when it accepts a review, but it
    checks the BUCKET; what decides whether a visitor sees the image is the public read
    host, which does not resolve yet. A broken image renders a torn rectangle exactly
    where the page is trying to prove competence.
  - The subtitle is conditional. It currently claims every quote is published on the
    Google profile; with reviews arriving from the link, that sentence becomes false for
    part of the same grid.
  - `aggregateRating` is NOT touched. Mixing first-party reviews into the 5.0/15 would
    make the number unverifiable against the Google profile, which is the whole reason
    that block was rewritten last week. These render without schema markup.
  - Reviews with no comment are filtered out. A card with stars and no words is weaker
    than no card, and the rating alone already lives in the badge.
  - `/published-reviews` is the post-verly-service#56 name. prod is still at #53 and
    answers 403 today, so the section is simply absent until #56 merges. I deliberately
    did not fall back to the old `/reviews/approved`: a silent fallback between two API
    versions hides which one is live exactly when that matters.
  - The workflow gained a daily `schedule`. Approving on Telegram would otherwise publish
    nothing until someone pushed, and the person who approves is not the person who
    deploys. A webhook from the Pi to GitHub would be faster and would need a secret, a
    public endpoint and a new way to fail.

Note on `API_BASE` in src/data/site.ts: #63 adds the same export, so whichever merges
second will want a one-line conflict resolve. Both blocks are identical — keep either.
Basing this on #63 instead would have stacked the PRs, and stacked content is how it gets
orphaned.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

**Base is `main`.**

## Nothing visible changes until three things happen
1. `verly-service#56` merges (renames the endpoint this reads)
2. A customer actually submits through `/avaliar.html` (#63) and you approve it on Telegram
3. For the PHOTOS specifically: the Cloudflare public hostname for `cdn.` — until then the
   build's HEAD check drops them and the review renders text-only, which is the correct
   degradation, not a bug

Until then this PR is inert by design: the build logs `403` and ships the site unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)