### PR TITLE
Fix neighborhood prefill and reduce quote form friction

### DIFF
--- a/public/js/ui-improvements.js
+++ b/public/js/ui-improvements.js
@@ -270,6 +270,8 @@ const SearchableSelect = {
         input.setAttribute('aria-expanded', 'false');
         input.setAttribute('aria-autocomplete', 'list');
         input.setAttribute('autocomplete', 'off');
+        const selectedOption = options.find(option => option.value === selectElement.value);
+        input.value = selectedOption ? selectedOption.text : '';
         
         // Create dropdown
         const dropdown = document.createElement('div');

--- a/src/components/QuoteForm.astro
+++ b/src/components/QuoteForm.astro
@@ -123,107 +123,103 @@ const {
                             <div class="form-error" id="phoneError"></div>
                         </div>
 
-                        <div class="form-group">
-                            <label class="form-label" for="email">
-                                E-mail
-                            </label>
-                            <input 
-                                type="email" 
-                                id="email" 
-                                name="email"
-                                class="form-control" 
-                                placeholder="seu@email.com"
-                                autocomplete="email"
-                            >
-                            <div class="form-error" id="emailError"></div>
-                            <div class="form-help">Opcional, mas nos ajuda a enviar o orçamento</div>
-                        </div>
-
-                        {/* Deixou de ser obrigatório. Nas 11 páginas de bairro ele já vem
-                            preenchido, então exigir não custava nada ali — mas na home
-                            custava, e era o terceiro obstáculo antes do envio. Quem atende
-                            pergunta o bairro na primeira frase da conversa; o formulário
-                            não precisa ser o lugar onde isso é decidido. */}
-                        <div class="form-group">
-                            <label class="form-label" for="neighborhood">
-                                Seu Bairro
-                            </label>
-                            <select
-                                id="neighborhood"
-                                name="neighborhood"
-                                class="form-control"
-                            >
-                                <option value="">Selecione seu bairro</option>
-                                {NEIGHBORHOOD_OPTIONS.map((o) => (
-                                  <option value={o} selected={o === neighborhood}>{o}</option>
-                                ))}
-                            </select>
-                            <div class="form-error" id="neighborhoodError"></div>
-                        </div>
-
-                        {/* Oito checkboxes obrigatórios eram, medindo a seção no celular, o
-                            maior pedaço dos 2.226px de altura do formulário — 2,6 telas — e
-                            o campo mais caro dele: obrigatório, com oito decisões, e o único
-                            cuja resposta o atendimento descobre em uma pergunta.
-                            Fechado num <details>, some da altura de quem não quer detalhar e
-                            continua inteiro para quem quer. Nenhuma opção foi removida: um
-                            <select> de serviço principal encurtaria mais, mas perderia o
-                            pedido de duas coisas ao mesmo tempo, que é comum aqui (box +
-                            espelho no mesmo banheiro).
-                            <details> nativo é o mesmo recurso que o FAQ já usa — zero JS. */}
-                        <details class="form-group services-details">
-                            <summary class="form-label services-summary">
-                                Serviços de interesse <span class="form-optional">(opcional)</span>
+                        {/* Tudo que não é necessário para iniciar o atendimento fica numa
+                            única decisão opcional. O bairro também fica aqui: nas páginas
+                            locais ele já vem preenchido e será enviado sem pedir confirmação;
+                            quem estiver pedindo para outro endereço ainda pode abrir e editar.
+                            Na home, continua vazio e opcional. */}
+                        <details class="form-group optional-details">
+                            <summary class="form-label optional-details-summary">
+                                Adicionar detalhes <span class="form-optional">(opcional)</span>
                             </summary>
-                            <div class="checkbox-group">
-                                <div class="checkbox-item">
-                                    <input type="checkbox" id="service1" name="services" value="Box para Banheiro">
-                                    <label for="service1">Box para Banheiro</label>
+
+                            <div class="optional-details-content">
+                                <div class="form-group">
+                                    <label class="form-label" for="email">
+                                        E-mail
+                                    </label>
+                                    <input
+                                        type="email"
+                                        id="email"
+                                        name="email"
+                                        class="form-control"
+                                        placeholder="seu@email.com"
+                                        autocomplete="email"
+                                    >
+                                    <div class="form-error" id="emailError"></div>
+                                    <div class="form-help">Nos ajuda a enviar o orçamento</div>
                                 </div>
-                                <div class="checkbox-item">
-                                    <input type="checkbox" id="service2" name="services" value="Sacada Envidraçada">
-                                    <label for="service2">Sacada Envidraçada</label>
+
+                                <div class="form-group">
+                                    <label class="form-label" for="neighborhood">
+                                        Seu Bairro
+                                    </label>
+                                    <select
+                                        id="neighborhood"
+                                        name="neighborhood"
+                                        class="form-control"
+                                    >
+                                        <option value="">Selecione seu bairro</option>
+                                        {NEIGHBORHOOD_OPTIONS.map((o) => (
+                                          <option value={o} selected={o === neighborhood}>{o}</option>
+                                        ))}
+                                    </select>
+                                    <div class="form-error" id="neighborhoodError"></div>
                                 </div>
-                                <div class="checkbox-item">
-                                    <input type="checkbox" id="service3" name="services" value="Guarda-corpo">
-                                    <label for="service3">Guarda-corpo</label>
+
+                                <div class="form-group">
+                                    <div class="form-label" id="services-label">Serviços de interesse</div>
+                                    <div class="checkbox-group">
+                                        <div class="checkbox-item">
+                                            <input type="checkbox" id="service1" name="services" value="Box para Banheiro">
+                                            <label for="service1">Box para Banheiro</label>
+                                        </div>
+                                        <div class="checkbox-item">
+                                            <input type="checkbox" id="service2" name="services" value="Sacada Envidraçada">
+                                            <label for="service2">Sacada Envidraçada</label>
+                                        </div>
+                                        <div class="checkbox-item">
+                                            <input type="checkbox" id="service3" name="services" value="Guarda-corpo">
+                                            <label for="service3">Guarda-corpo</label>
+                                        </div>
+                                        <div class="checkbox-item">
+                                            <input type="checkbox" id="service4" name="services" value="Portas de Vidro">
+                                            <label for="service4">Portas de Vidro</label>
+                                        </div>
+                                        <div class="checkbox-item">
+                                            <input type="checkbox" id="service5" name="services" value="Janelas de Alumínio">
+                                            <label for="service5">Janelas de Alumínio</label>
+                                        </div>
+                                        <div class="checkbox-item">
+                                            <input type="checkbox" id="service6" name="services" value="Espelhos">
+                                            <label for="service6">Espelhos</label>
+                                        </div>
+                                        <div class="checkbox-item">
+                                            <input type="checkbox" id="service7" name="services" value="Divisórias">
+                                            <label for="service7">Divisórias</label>
+                                        </div>
+                                        <div class="checkbox-item">
+                                            <input type="checkbox" id="service8" name="services" value="Tampos de Mesa">
+                                            <label for="service8">Tampos de Mesa</label>
+                                        </div>
+                                    </div>
                                 </div>
-                                <div class="checkbox-item">
-                                    <input type="checkbox" id="service4" name="services" value="Portas de Vidro">
-                                    <label for="service4">Portas de Vidro</label>
-                                </div>
-                                <div class="checkbox-item">
-                                    <input type="checkbox" id="service5" name="services" value="Janelas de Alumínio">
-                                    <label for="service5">Janelas de Alumínio</label>
-                                </div>
-                                <div class="checkbox-item">
-                                    <input type="checkbox" id="service6" name="services" value="Espelhos">
-                                    <label for="service6">Espelhos</label>
-                                </div>
-                                <div class="checkbox-item">
-                                    <input type="checkbox" id="service7" name="services" value="Divisórias">
-                                    <label for="service7">Divisórias</label>
-                                </div>
-                                <div class="checkbox-item">
-                                    <input type="checkbox" id="service8" name="services" value="Tampos de Mesa">
-                                    <label for="service8">Tampos de Mesa</label>
+
+                                <div class="form-group">
+                                    <label class="form-label" for="message">
+                                        Descreva Seu Projeto
+                                    </label>
+                                    <textarea
+                                        id="message"
+                                        name="message"
+                                        class="form-control"
+                                        rows="4"
+                                        placeholder="Ex: Preciso de um box de 1,20m x 1,80m para banheiro. Gostaria de receber orçamento."
+                                    ></textarea>
+                                    <div class="form-help">Quanto mais detalhes, melhor será nosso orçamento</div>
                                 </div>
                             </div>
                         </details>
-
-                        <div class="form-group">
-                            <label class="form-label" for="message">
-                                Descreva Seu Projeto (Opcional)
-                            </label>
-                            <textarea 
-                                id="message" 
-                                name="message"
-                                class="form-control" 
-                                rows="4"
-                                placeholder="Ex: Preciso de um box de 1,20m x 1,80m para banheiro. Gostaria de receber orçamento."
-                            ></textarea>
-                            <div class="form-help">Quanto mais detalhes, melhor será nosso orçamento</div>
-                        </div>
 
                         {/* Cor de CTA, não azul de marca: o botão que fecha a conversão é o
                             único que precisava do âmbar e era o único que não usava. */}

--- a/src/styles/index-inline.css
+++ b/src/styles/index-inline.css
@@ -1231,11 +1231,10 @@
 .faq-item[open] > summary::after { content: '\2212'; }
 .faq-item > p { margin: 0.75rem 0 0; color: #4b5563; }
 
-/* Bloco de serviços do formulário, no mesmo mecanismo do FAQ acima — nativo, sem JS.
-   O `+`/`−` é o que diz que existe conteúdo dobrado ali: sem o affordance, "Serviços
-   de interesse (opcional)" pareceria só um rótulo, e quem QUERIA detalhar não acharia
-   as oito opções. O alvo de toque cobre a linha inteira, não só o texto. */
-.services-details > .services-summary {
+/* Detalhes opcionais do formulário, no mesmo mecanismo do FAQ acima — nativo, sem JS.
+   O `+`/`−` deixa claro que e-mail, bairro, serviços e mensagem continuam disponíveis.
+   O alvo de toque cobre a linha inteira, não só o texto. */
+.optional-details > .optional-details-summary {
     cursor: pointer;
     list-style: none;
     display: flex;
@@ -1245,16 +1244,17 @@
     min-height: 44px;
     margin-bottom: 0;
 }
-.services-details > .services-summary::-webkit-details-marker { display: none; }
-.services-details > .services-summary::after {
+.optional-details > .optional-details-summary::-webkit-details-marker { display: none; }
+.optional-details > .optional-details-summary::after {
     content: '+';
     font-size: 1.5rem;
     line-height: 1;
     flex-shrink: 0;
     color: var(--gray);
 }
-.services-details[open] > .services-summary::after { content: '\2212'; }
-.services-details[open] > .checkbox-group { margin-top: 0.75rem; }
+.optional-details[open] > .optional-details-summary::after { content: '\2212'; }
+.optional-details[open] > .optional-details-content { margin-top: 0.75rem; }
+.optional-details-content > .form-group:last-child { margin-bottom: 0; }
 
 /* "(opcional)" em peso normal: o rótulo é negrito, e a palavra que mais importa aqui é
    justamente a que dispensa o visitante de responder. */


### PR DESCRIPTION
## Summary
- Mirror the native neighborhood selection into the searchable visual input so local landing pages do not appear to ask for known context again.
- Put email, neighborhood, services, and project notes behind one native optional disclosure, leaving the default reading order as name, WhatsApp, optional details, and submit.
- Keep neighborhood inside the disclosure because local pages already know and submit it; visitors only need to open the block when they want to change the service address. The home still starts empty.

## Built-output proof
Measurements used the generated `dist/` HTML in headless Google Chrome at a 390x844 viewport. Commands:

```sh
npm ci && npm run build
python3 -m http.server 4174 --directory dist
"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless=new --disable-gpu --user-data-dir=/tmp/verly-fix-c-chrome --remote-debugging-port=9224 about:blank
node --input-type=module -e '<CDP script using Emulation.setDeviceMetricsOverride({width:390,height:844,deviceScaleFactor:1,mobile:true}), getBoundingClientRect(), and a stubbed fetch submission>'
```

The same CDP script was run before and after the source change and queried `#contato`, `#contactForm`, `#submitBtn`, the native neighborhood select, and `.searchable-select-input`.

| 390x844 measurement | Before | After |
| --- | ---: | ---: |
| `#contato` height | 1806.2 px | 1338.1 px |
| `#contactForm` height | 895.5 px | 427.4 px |
| `.contact-form` card height | 955.5 px | 487.4 px |
| Submit bottom from section top | 1080.8 px | 612.8 px |
| Submit relative to 844 px fold | 236.8 px below | 231.2 px above |

Neighborhood checks in built pages:
- `/realengo.html`: native `Realengo`, visual `Realengo`.
- `/campo-grande.html`: native `Campo Grande`, visual `Campo Grande`.
- `/index.html`: native and visual values both start empty; the visual input is neither disabled nor read-only, and selecting `Anil` updated both values to `Anil`.

Payload compatibility was checked by replacing `fetch` in the built page with a local capture stub, filling every optional field, and calling `requestSubmit()`; no request reached the API. The POST retained the existing keys: `submission_id`, `name`, `phone`, `email`, `neighborhood`, `city`, `description`, `screen_height`, `screen_width`, `user_agent`, `referrer`, `submission_date`, `device_type`, `utm_source`, `utm_medium`, and `utm_campaign`. The captured payload included `neighborhood: "Campo Grande"`; services and the message remained encoded in `description`. Only name and phone reported `required: true`. `public/js/app.js` was not changed.

## Verification
- `npm ci && npm run build` — passed, including the contrast gate and all 17 static pages.
- Built-output dead-anchor, local asset, and required-file checks equivalent to the pull-request workflow — passed.
- `git diff --check` — passed.

Everything required by this change was verified locally; no known verification gaps remain.

Made with [Cursor](https://cursor.com)