### PR TITLE
Bound lead submission wait and preserve a WhatsApp exit

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -554,6 +554,8 @@ const LEAD_ENDPOINT = 'https://api.verlyvidracaria.com/verly-service/leads';
 const LEAD_FOREGROUND_ATTEMPTS = 2;
 const LEAD_BACKGROUND_ATTEMPTS = 3;
 const LEAD_BACKOFF_MS = [800, 2500, 6000];
+// 2 × 4 s + 800 ms de backoff: a pessoa recebe uma saída em no máximo 8,8 s.
+const LEAD_ATTEMPT_TIMEOUT_MS = 4000;
 
 const LEAD_QUEUE_KEY = 'verly_pending_leads';
 
@@ -606,6 +608,9 @@ function isRetryableStatus(status) {
  * @returns {'success'|'error'|'retryable_error'|'fetch_error'}
  */
 async function postLead(payload) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), LEAD_ATTEMPT_TIMEOUT_MS);
+
     try {
         const response = await fetch(LEAD_ENDPOINT, {
             method: 'POST',
@@ -615,7 +620,8 @@ async function postLead(payload) {
             body: JSON.stringify(payload),
             // Sobrevive ao unload: quem envia e fecha a aba (ou é redirecionado para o
             // WhatsApp) não perde mais a requisição no meio do caminho.
-            keepalive: true
+            keepalive: true,
+            signal: controller.signal
         });
 
         if (response.ok) {
@@ -632,6 +638,8 @@ async function postLead(payload) {
         // fetch lança em offline, DNS, CORS, timeout e servidor inalcançável.
         console.error('Error submitting form:', error);
         return 'fetch_error';
+    } finally {
+        clearTimeout(timeoutId);
     }
 }
 


### PR DESCRIPTION
## Summary
- abort each lead POST after 4 seconds so two foreground attempts plus the existing 800 ms backoff cannot leave a visitor on an indefinite spinner
- keep the fallback sequential: WhatsApp is offered only after both API attempts resolve or abort, and leave a persistent prefilled link in addition to the existing automatic open
- preserve `keepalive: true` on every POST while adding the abort signal

## Timeout choice
Four seconds gives a mobile request a brief chance to survive an intermittent connection without making one attempt feel indefinite. With two foreground attempts and the existing 800 ms backoff, network waiting is capped at 8.8 seconds. In the built-page browser proof, the complete interval from clicking submit to a visible WhatsApp link was 9,071 ms, including browser/UI overhead. This keeps the exit under ten seconds while retaining one retry.

## Verification
- `npm ci && npm run build` — passed; generated all 17 pages and the contrast gate passed
- built `dist/index.html` was served locally in Chromium with the production lead URL intercepted by a handler that never responded: 2 attempts, then a visible persistent WhatsApp link after 9,071 ms; the link contained the submitted request text
- the same built page was tested with a 200 stub returning the production `LeadDTO` shape (`id`, `name`, `phone`, `city`, `description`, `createdDate`, `status`): confirmation was visible after 1 request
- inspected `dist/js/app.js`: the emitted fetch options contain both `keepalive: true` and `signal: controller.signal`; I did not perform a real tab-unload network capture
- the production API was not called and no test lead was created

## Duplication hazard
This chooses fail-fast-then-offer rather than offering WhatsApp in parallel, so there is no intentionally active browser request when the link appears. A duplicate is still possible in the uncertain-delivery case: the API may store a POST but delay its response beyond 4 seconds; the browser aborts its wait, exhausts the retry, queues the same submission, and the visitor clicks the WhatsApp link. The ERP can then receive the API lead while the shop also receives the WhatsApp conversation. Closing that gap requires the WhatsApp bot and ERP to carry and deduplicate a shared attribution/submission key; direct WhatsApp links do not carry one today.

Made with [Cursor](https://cursor.com)