### PR TITLE
Fix analytics lead semantics and CTA exposure tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ com a das 11 páginas de bairro.
 | Evento | Descrição | Dados Capturados |
 |--------|-----------|------------------|
 | `page_view` | Carregamento da página (o automático do gtag, um por acesso) | page_location, page_title, page_referrer |
+| `whatsapp_impression` | CTA de WhatsApp realmente visível (1x/context/pageview) | context, click_source, button_text |
 | `whatsapp_click` | Clique em WhatsApp | context, click_source, button_text |
 | `contact_link_click` | Clique em e-mail/endereço | event_name, link_type, link_text |
 | `phone_click` | Clique em `tel:` | phone_number, click_location |
@@ -220,7 +221,9 @@ com a das 11 páginas de bairro.
 | `cta_click` | Clique em botão de CTA | button_text, button_location, target_section |
 | `service_interaction` | Clique em card de serviço | service_name, service_position |
 | `form_interaction` | Cada passo do formulário | form_action, field_name |
-| `generate_lead` | Formulário enviado com sucesso | services, neighborhood, api_status |
+| `lead_submit_attempt` | Payload válido enviado à API | services, neighborhood, has_email, has_message |
+| `generate_lead` | API confirmou o lead (`2xx`) | services, neighborhood, api_status |
+| `lead_recovered` | Fila local foi aceita posteriormente | recovery_reason, delivery_attempts |
 | `scroll` | Profundidade de scroll | percent_scrolled (25/50/75/100) |
 | `section_view` | Visualização de seção | section_name, section_id |
 | `engagement_milestone` | 30s / 60s / 120s na página | milestone_name, milestone_value |

--- a/docs/ANALYTICS_PLAN.md
+++ b/docs/ANALYTICS_PLAN.md
@@ -35,11 +35,14 @@ log aparece, e não há evento que escape da segmentação.
 | `service_interaction` | `app.js:115` ← `:724` | clique em qualquer ponto de `.service-card` | `service_name: "Box para Banheiro"`, `service_position: 1`, `interaction_type: "click"` | baixa (6 cards) |
 | `navigation_click` | `app.js:147` ← `:623`, `:732`, `:741`, `:825` | `.nav-link`, links do rodapé, âncoras `#`, toggle do menu mobile | `link_text: "Serviços"`, `link_target: "#servicos"`, `navigation_type: "menu"` (`menu`\|`footer`\|`internal_link`\|`mobile_menu_toggle`) | média (~30 combinações de texto/alvo) |
 | `phone_click` | `app.js:136` ← `:750` | clique em `a[href^="tel:"]` | `phone_number: "+552134216066"` (número **da loja**), `click_location: "footer"` | baixa |
-| `whatsapp_click` | `whatsapp-cta.js` (listener delegado no `document`) | clique em qualquer link de WhatsApp — **um** por clique | `context: "service-sacada"`, `click_source`, `button_text: "Pedir Orçamento"` | `context` baixa (11 valores; ver §5.4) |
+| `whatsapp_impression` | `whatsapp-cta.js` (`IntersectionObserver`) | CTA de WhatsApp fica realmente visível — **1x por `context` por pageview** | `context: "service-sacada"`, `click_source`, `button_text: "Pedir Orçamento"` | mesma cardinalidade baixa de `context`; é o denominador de §5.4 |
+| `whatsapp_click` | `whatsapp-cta.js` (listener delegado no `document`) | clique real em qualquer link de WhatsApp — **um** por clique | `context: "service-sacada"`, `click_source`, `button_text: "Pedir Orçamento"` | `context` baixa (inclui `form_fallback`/`form_error`; ver §5.4) |
 | `contact_link_click` | `whatsapp-cta.js` | clique em `[data-track]` — **2** links do rodapé, e-mail e endereço (`Footer.astro:78,84`); WhatsApp e telefone saem como os próprios eventos | `link_id: "footer_email_click"`, `link_type: "mailto"`, `link_text` | baixa (2) |
 | `form_interaction` | `app.js:84` | 10 gatilhos, ver tabela abaixo | `form_name: "contact_form"`, `form_action: "field_focus"`, `field_name: "phone"`, `field_value_length: 15` (só quando há valor), `error_message: "Telefone inválido…"` (só em erro) | `form_action` baixa (10); `field_name` baixa (7: `name`, `phone`, `email`, `neighborhood`, `message`, `services`, `all_fields`) |
 | `engagement_milestone` | `app.js:158` ← `:696` | 30s / 60s / 120s após `DOMContentLoaded` | `milestone_name: "time_60s"`, `milestone_value: 60` | baixa (3) |
-| `generate_lead` | `app.js` | submit válido **e** resposta da API — inclusive quando a API falha | `lead_source: "contact_form"`, `services: "box,espelhos"` (**slugs**, ver `SERVICE_SLUGS`), `services_count: 2`, `neighborhood: "Realengo"`, `api_status`, `delivery_attempts`, `lead_queued`, `has_email`, `has_message` | `services` combinatória mas **curta** — 8 slugs somam bem menos que o limite de 100 caracteres do GA4; `neighborhood` baixa (11) |
+| `lead_submit_attempt` | `app.js` | payload válido está prestes a ser enviado à API | `lead_source: "contact_form"`, `services: "box,espelhos"`, `services_count: 2`, `neighborhood: "Realengo"`, `has_email`, `has_message` | denominador de entrega; nenhum parâmetro contém PII |
+| `generate_lead` | `app.js` | API confirmou aceitação (`2xx`) no envio em primeiro plano | os parâmetros de `lead_submit_attempt` + `api_status: "success"`, `delivery_attempts` | conversão confirmada; nunca sai para erro HTTP ou de rede |
+| `lead_recovered` | `app.js` | fila local foi aceita pela API em `online` ou novo page load | `lead_source`, `recovery_reason`, `delivery_attempts`, `queued_seconds` | desfecho distinto porque não foi confirmado no submit original |
 | `conversion` (Ads) | `app.js:520` | **nunca hoje**: `ADS_CONVERSION_LABEL` é `''` (`app.js:17`) | `send_to`, `value: 1.0`, `currency: "BRL"` | — |
 | `review_started` | `avaliar.astro` | primeira estrela escolhida, 1x por acesso | `rating: 5` | baixa (5) |
 | `review_submitted` | `avaliar.astro` | 202 do `POST /reviews` | `rating: 5`, `photo_count: 3`, `photo_failures: 0`, `has_comment: true` | `rating` baixa; as contagens são numéricas |
@@ -51,13 +54,13 @@ tráfego dela vem de link em conversa, nunca de busca. **A leitura que eles habi
 uma só, e é operacional, não de marketing:** quantos links enviados viram avaliação
 (`review_started` ÷ `review_submitted` ÷ links criados no Telegram). Enquanto o volume
 for de dezenas, leia contagem bruta — taxa em amostra desse tamanho não afirma nada
-(§6c).
+(§6d).
 
 Valores de `form_action`, com a linha que os emite:
 
 | `form_action` | Linha | Observação |
 |---|---|---|
-| `start` | `app.js:786` | primeiro focus em qualquer um dos 5 campos |
+| `start` | `app.js` | primeiro focus em qualquer campo, incluindo o grupo `services`; **1x por formulário por pageview** |
 | `field_focus` | `app.js:789` | **todo** focus, não só o primeiro — contagem infla por pessoa |
 | `field_blur` | `app.js:794` | passa o valor; sai só `field_value_length` |
 | `field_complete` | `app.js:359` | campo válido e preenchido |
@@ -97,7 +100,7 @@ de evento; a lista usa 15.
 | `neighborhood` | Evento | bairro **declarado no formulário** — pode divergir da página | §5.1 (tabela C) |
 | `services` | Evento | único registro do que o lead pediu | §5.2 (via filtro "contém") |
 | `context` | Evento | identidade do CTA de WhatsApp | §5.4 |
-| `click_source` | Evento | origem do `whatsapp_click` do `app.js` (o que **não** tem `context`) | §5.4; descartável quando o duplo disparo for eliminado |
+| `click_source` | Evento | categoria de origem de `whatsapp_click` e `whatsapp_impression` | §5.4 |
 | `form_action` | Evento | etapa do formulário — sem ela o funil do form não existe | §4, §5.3 |
 | `field_name` | Evento | campo da etapa | §5.3 |
 | `error_message` | Evento | qual validação barrou | §5.3 |
@@ -105,7 +108,7 @@ de evento; a lista usa 15.
 | `button_location` | Evento | onde estava o botão do `cta_click` | §4, §5.4 |
 | `button_text` | Evento | desambigua dois CTAs no mesmo `button_location` | §5.4 |
 | `service_name` | Evento | card de serviço clicado | §5.2 (sinal de interesse) |
-| `api_status` | Evento | separa lead salvo de lead com falha de API | §4 (etapa 6), §6 |
+| `api_status` | Evento | confirma que `generate_lead` corresponde a aceitação da API | auditoria de conversão |
 | `rating` | Evento | nota da avaliação (1-5); é o que separa elogio de reclamação | §1, eventos `review_*` |
 
 **Zero dimensões de escopo de usuário.** Nada na instrumentação descreve atributo
@@ -131,8 +134,8 @@ Enquanto estiver no Administrador, faça também: **Exibição de dados → Rete
 
 | Evento | Marcar? | Por que |
 |---|---|---|
-| `generate_lead` | Sim — principal | é o único evento que corresponde a um pedido de orçamento identificado |
-| `whatsapp_click` | Sim — secundário, **depois** de corrigir o disparo duplo | é intenção, não lead: o WhatsApp não devolve nada ao site |
+| `generate_lead` | Sim — principal | é o único evento que corresponde a um pedido aceito pela API |
+| `whatsapp_click` | Sim — secundário | é handoff real, mas ainda intenção: o WhatsApp não devolve confirmação de conversa ao site |
 | `phone_click`, `contact_link_click` | Não | volume baixo e mesma intenção do WhatsApp; viram ruído na contagem |
 
 Consequência de marcar os dois: uma sessão que clica no WhatsApp **e** envia o formulário
@@ -143,10 +146,8 @@ conta **duas** "conversões". A métrica "Sessões com evento principal" não so
   o evento escolhido no seletor), nunca o total agregado.
 - Só `generate_lead` vai para o Google Ads (§7). Se `whatsapp_click` for importado, o
   Smart Bidding otimiza para cliques que podem nunca virar conversa.
-- Discordância: **não marque `whatsapp_click` antes do fix do disparo duplo**. Dois ouvintes
-  independentes (`app.js:701` e `whatsapp-cta.js:386`) disparam no mesmo clique, então a
-  contagem de eventos principais sairia com o **dobro** dos cliques reais. Se marcar antes,
-  leia só a métrica de **sessões** com o evento, que não duplica.
+- O fallback do formulário só emite `whatsapp_click` quando a pessoa clica no link
+  "Continuar no WhatsApp". Renderizar o link, ou uma falha da API por si só, não é conversão.
 
 ---
 
@@ -158,8 +159,8 @@ conta **duas** "conversões". A métrica "Sessões com evento principal" não so
 |---|---|---|---|
 | 1 | Chegou | `session_start` | nenhum |
 | 2 | Viu os serviços | `section_view` | `section_id` exatamente `servicos` |
-| 3 | Demonstrou intenção | `cta_click` **ou** `whatsapp_click` (condição OR na mesma etapa) | `cta_click`: `button_location` **diferente de** `contact_form` (o botão de envio é a etapa 5, não intenção); `whatsapp_click`: `context` **diferente de** `(não definido)`, senão o clique conta duas vezes |
-| 4 | Começou o formulário | `form_interaction` | `form_action` exatamente `field_focus` |
+| 3 | Demonstrou intenção | `cta_click` **ou** `whatsapp_click` (condição OR na mesma etapa) | `cta_click`: `button_location` **diferente de** `contact_form` (o botão de envio é a etapa 5, não intenção) |
+| 4 | Começou o formulário | `form_interaction` | `form_action` exatamente `start` |
 | 5 | Pediu orçamento | `generate_lead` | nenhum |
 | 6 | Confirmou | `page_view` | "Caminho da página e classe da tela" exatamente `/obrigado.html` |
 
@@ -170,11 +171,9 @@ Três avisos sobre este funil, todos verificados no código:
 - **Por isso o funil é aberto.** A etapa 3 pode acontecer **antes** da 2: o CTA de
   WhatsApp do hero (`src/pages/index.astro:47`) está acima da seção de serviços. Num funil
   fechado e ordenado, quem clica no hero é descartado, e o hero é o CTA mais exposto do site.
-- **Etapa 5 → 6 perde gente por projeto.** `generate_lead` dispara mesmo quando a API
-  falha (`app.js:508` com `api_status: "error"`), e nesse caminho o visitante vai para o
-  WhatsApp, não para `/obrigado.html` (`app.js:549-571`). Para isolar, filtre a etapa 5 com
-  `api_status = success`. Ainda assim há perda: o redirecionamento espera 1200 ms
-  (`app.js:545`) e quem fecha a aba antes não gera o pageview.
+- **Etapa 5 → 6 ainda pode perder gente.** `generate_lead` já significa API aceita, mas o
+  redirecionamento espera 1200 ms; quem fecha a aba antes não gera o pageview de
+  `/obrigado.html`.
 - **Etapa 4 não cobre os checkboxes.** Ver §5.3.
 
 ---
@@ -275,27 +274,22 @@ principais por sessão", que só existe depois de §3.
 ### 5.4 Qual CTA converte
 
 - **Pergunta:** quais dos ~11 links de WhatsApp da home merecem existir?
-- **Tipo:** formato livre. Linhas: `context`; colunas: `page_type`; métrica: Contagem de
-  eventos. Filtro: Nome do evento exatamente `whatsapp_click`.
-- **Filtro obrigatório:** `context` **diferente** de `(não definido)`. Motivo: o mesmo
-  clique dispara `whatsapp_click` duas vezes, por dois ouvintes independentes
-  (`app.js:701-707` e `whatsapp-cta.js:386-408`), e só o segundo carrega `context`.
-  Filtrando, cada clique conta uma vez e o número volta a ser clique.
+- **Tipo:** duas tabelas de formato livre, ambas com linhas `context` e colunas
+  `page_type`. Na primeira, filtre Nome do evento = `whatsapp_impression`; na segunda,
+  Nome do evento = `whatsapp_click`. Divida cliques por impressões fora do GA4.
+- **Por que a impressão é o denominador:** sticky só fica visível após 30% de rolagem,
+  flutuante recua quando seria redundante/obstruiria conteúdo e CTAs de serviço só entram
+  no viewport com scroll. Contagem bruta de clique mistura atratividade com exposição.
+- **Cardinalidade:** cada `context` emite no máximo uma impressão por pageview, mesmo se o
+  CTA sair e voltar ao viewport. Cliques continuam um por ação real e podem ser mais de um
+  no mesmo pageview.
 - **Valores de `context` que existem:** `floating-button` (`Base.astro:153`),
   `sticky-cta` (`whatsapp-cta.js:253`), `footer-whatsapp` (`Footer.astro:62`),
   `thank-you-page` (`obrigado.astro:32`), `service-*` (6 valores, `whatsapp-cta.js:318`),
-  e `unknown`.
-- **Limite de leitura:** `unknown` é a soma de **três** CTAs sem `data-context` — hero da
-  home (`index.astro:47`), faixa do meio (`index.astro:166`) e hero das páginas de bairro
-  (`[slug].astro:69`). Quebrar por `page_type` separa o de bairro dos dois da home, mas não
-  separa hero de faixa. O CTA mais exposto do site é o que hoje não se consegue ler.
-  Follow-up de código: `data-context` nesses três links.
-- **Exposição, não popularidade:** o flutuante fica oculto em três situações
-  (`whatsapp-cta.js:116`) e a sticky só aparece após 30% de rolagem
-  (`whatsapp-cta.js:269`). Volume baixo nesses dois pode significar "não estava na tela" —
-  compare cada CTA com a própria série no tempo, não com os outros.
-- **Como ler:** zero clique em 4 semanas com tráfego confirmado = remover. Diferença entre
-  CTAs vivos precisa de ~30 cliques por CTA para valer discussão.
+  `hero-whatsapp`, `cta-band`, `neighborhood-hero` e os handoffs
+  `form_fallback`/`form_error`.
+- **Como ler:** zero clique com impressões confirmadas é candidato a remoção. Diferença
+  entre CTAs vivos ainda precisa de ~30 cliques por CTA para valer discussão.
 - **Decide:** quais CTAs cortar. Onze links de WhatsApp numa página é muito, e todos
   competem pelo mesmo clique.
 
@@ -312,7 +306,26 @@ painel). Se existir, o histórico bruto é recuperável por SQL; se não, vincul
 (**Administrador → Vinculações de produtos → BigQuery**) — é o único jeito de nunca mais
 perder parâmetro por falta de registro.
 
-**(b) O `page_view` duplicado.** Valeu para todo o período anterior
+**(b) Há uma quebra semântica no deploy deste plano.** Nenhum nome de evento foi
+renomeado, mas comparar séries atravessando o deploy mistura definições diferentes:
+
+- `generate_lead` mantinha esse nome desde aproximadamente 2026-08-10, porém incluía
+  erro HTTP e erro de rede. Depois do deploy, só inclui aceite `2xx`. O emissor de
+  `generate_lead` nos caminhos de falha foi **retirado**.
+- `whatsapp_click` também mantém o nome. O emissor sintético do fallback — executado antes
+  de um `window.open` por timer — foi **retirado**; depois do deploy o evento exige clique
+  real em link. `form_fallback`/`form_error` continuam como valores de `context`, agora
+  apenas quando houve handoff.
+- `form_interaction` + `form_action=start` mantém nome e parâmetros, mas passa de até um
+  evento por campo para exatamente um por formulário/pageview.
+- `lead_submit_attempt` e `whatsapp_impression` são novos. `lead_recovered` mantém o
+  significado existente.
+
+Registro de dimensão personalizada **não é retroativo** (§2), e correção de código também
+não reescreve evento histórico. Para qualquer taxa afetada, use o deploy como corte e não
+some os dois períodos como se fossem uma série homogênea.
+
+**(c) O `page_view` duplicado.** Valeu para todo o período anterior
 (`Base.astro:113` + `app.js:693`). O efeito é mais específico do que "tudo pela metade":
 
 | Métrica histórica | Distorcida? |
@@ -327,7 +340,7 @@ perder parâmetro por falta de registro.
 Ou seja: comparar meses entre si continua válido; comparar valor absoluto de antes com
 depois do fix, não.
 
-**(c) Volume.** Não medi o tráfego atual do site — os números abaixo são estatística, não
+**(d) Volume.** Não medi o tráfego atual do site — os números abaixo são estatística, não
 dado da Verly. Vidraçaria de bairro tem tráfego baixo, e isso limita o que cada exploração
 pode afirmar:
 
@@ -354,7 +367,7 @@ usuários e a tabela de bairros pode esconder exatamente o bairro que você quer
 propriedade de baixo volume, não ative. E `section_view` é 1x por seção por pageview: taxa
 de "quem viu serviços" é por pageview, não por pessoa.
 
-**(d) Ruído a limpar — resolvido em código, uma coisa sobra para o painel.**
+**(e) Ruído a limpar — resolvido em código, uma coisa sobra para o painel.**
 
 | ruído | estado |
 |---|---|
@@ -364,6 +377,9 @@ de "quem viu serviços" é por pageview, não por pessoa.
 | `page_view` duplicado (`Base.astro` + `app.js`) | ✅ sobrou o automático |
 | `timestamp` em todo evento, gastando cota de dimensão | ✅ removido |
 | `services` cortando em 100 caracteres na seleção grande | ✅ virou lista de slugs + `services_count` |
+| `form_interaction.start` saindo uma vez por campo | ✅ uma vez por formulário/pageview |
+| `generate_lead` contando falha de API/rede | ✅ só aceite `2xx`; tentativa virou `lead_submit_attempt` |
+| fallback emitindo `whatsapp_click` antes de `window.open` | ✅ clique real no link de handoff |
 
 ⚠️ **O que sobra é seu, e é no painel:** o evento `scroll` **automático** da Medição
 avançada dispara a 90%. O do site agora se chama `scroll_depth` (25/50/75/100), então os

--- a/docs/GA4_TRACKING_GUIDE.md
+++ b/docs/GA4_TRACKING_GUIDE.md
@@ -57,10 +57,11 @@ Este documento descreve **todos os eventos do Google Analytics 4** implementados
 
 ---
 
-### 3. **generate_lead** (Padrão GA4 - Conversão)
+### 3. **lead_submit_attempt** + **generate_lead**
 
-**Quando:** Formulário enviado com sucesso  
-**Tipo:** Conversão Principal  
+**Quando:** `lead_submit_attempt` sai para cada payload válido prestes a ser enviado;
+`generate_lead` sai apenas quando a API confirma aceitação (`2xx`).
+**Tipo:** Tentativa + Conversão Principal confirmada
 
 **Parâmetros:**
 ```javascript
@@ -68,14 +69,14 @@ Este documento descreve **todos os eventos do Google Analytics 4** implementados
   lead_source: 'contact_form',
   services: 'Box para Banheiro, Sacada Envidraçada',
   neighborhood: 'Barra da Tijuca',
-  api_status: 'success', // ou 'error'
+  api_status: 'success', // presente apenas em generate_lead
   has_email: true,
   has_message: true,
   timestamp: '...'
 }
 ```
 
-**Objetivo:** Rastrear conversões e qualidade dos leads
+**Objetivo:** Medir tentativa → aceite sem contar falha HTTP/rede como lead
 
 ---
 
@@ -140,23 +141,27 @@ Este documento descreve **todos os eventos do Google Analytics 4** implementados
 
 ### 6. **whatsapp_click** (Customizado)
 
-**Quando:** Clique em qualquer link do WhatsApp  
+**Quando:** Clique real em qualquer link do WhatsApp, inclusive o link de handoff exibido
+após falha do formulário. Renderizar o link não dispara o evento.
 **Tipo:** Interação + Conversão  
 
 **Parâmetros:**
 ```javascript
 {
-  click_source: 'floating_button', // 'floating_button', 'hero_cta', 'form_success', 'form_fallback', 'form_error'
-  has_pre_filled_message: true,
-  message_length: 145,
-  timestamp: '...'
+  context: 'form_fallback',
+  click_source: 'inline_button',
+  button_text: 'Continuar no WhatsApp'
 }
 ```
 
 **Locais Rastreados:**
 - Botão flutuante (canto inferior direito)
 - Hero CTA "WhatsApp Direto"
-- Fallback após erro da API
+- Link de handoff após erro da API
+
+O evento `whatsapp_impression` usa os mesmos parâmetros e dispara no máximo uma vez por
+`context` por pageview quando o CTA fica realmente visível. Ele é o denominador correto
+para comparar CTAs cuja exposição depende de scroll/visibilidade.
 
 **Objetivo:** Medir conversões via WhatsApp
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -182,26 +182,6 @@ function trackServiceClick(serviceName, servicePosition) {
 }
 
 /**
- * Track WhatsApp interaction
- *
- * Só os desvios para o WhatsApp que NÃO são clique (fallback e erro do formulário)
- * passam por aqui. O clique em si tem um emissor só, o ouvinte delegado do
- * whatsapp-cta.js — ver o comentário em initCompleteAnalytics.
- *
- * `context` e `click_source` saem com o mesmo valor de propósito: o evento tem UM
- * formato só, então uma tabela por qualquer um dos dois parâmetros mostra o
- * fallback junto dos cliques em vez de "(não definido)".
- */
-function trackWhatsAppClick(source, message = '') {
-    trackGA4Event('whatsapp_click', {
-        context: source, // 'form_fallback', 'form_error'
-        click_source: source,
-        has_pre_filled_message: !!message,
-        message_length: message ? message.length : 0
-    });
-}
-
-/**
  * Track phone click
  */
 function trackPhoneClick(phoneNumber, location) {
@@ -325,6 +305,40 @@ function clearAlert() {
     const alertDiv = document.getElementById('formAlert');
     alertDiv.style.display = 'none';
     alertDiv.innerHTML = '';
+}
+
+/**
+ * Exibe a saída de contingência como um link real.
+ *
+ * `window.open()` disparado por timer não é uma ação da pessoa (e navegadores ainda
+ * podem bloqueá-lo como popup). O link mantém nome/telefone/mensagem no handoff, mas
+ * o analytics só acontece quando a pessoa de fato clica nele.
+ */
+function showWhatsAppHandoff(message, whatsappURL, context) {
+    showAlert(message, 'error');
+
+    const alertDiv = document.getElementById('formAlert');
+    const alert = document.createElement('div');
+    alert.className = 'form-alert error';
+
+    const icon = document.createElement('span');
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = '!';
+
+    const content = document.createElement('span');
+    content.appendChild(document.createTextNode(`${message} `));
+
+    const handoff = document.createElement('a');
+    handoff.href = whatsappURL;
+    handoff.target = '_blank';
+    handoff.rel = 'noopener noreferrer';
+    handoff.dataset.context = context;
+    handoff.textContent = 'Continuar no WhatsApp';
+    content.appendChild(handoff);
+
+    alert.append(icon, content);
+    alertDiv.replaceChildren(alert);
+    alertDiv.style.display = 'block';
 }
 
 /**
@@ -725,9 +739,9 @@ async function flushLeadQueue(reason) {
             }
 
             if (result.status === 'success') {
-                // NÃO é um generate_lead: a conversão já foi contada no envio. Este
-                // evento é o que fecha o buraco de leitura — sem ele, o lead que a
-                // fila recuperou fica para sempre como api_status=fetch_error.
+                // Recuperação tem evento próprio: o submit original não foi aceito e
+                // portanto não emitiu generate_lead. Assim o relatório distingue um
+                // lead confirmado em primeiro plano de um que só chegou pela fila.
                 trackGA4Event('lead_recovered', {
                     lead_source: 'contact_form',
                     recovery_reason: reason,
@@ -835,6 +849,20 @@ async function handleFormSubmit(event) {
         utm_medium: getUrlParam('utm_medium') || '',
         utm_campaign: getUrlParam('utm_campaign') || ''
     };
+
+    // Evento próprio para o denominador de entrega. Diferente do
+    // form_interaction.submit_attempt (que acontece antes da validação), este só sai
+    // quando existe um payload válido prestes a ser enviado. Nenhum dado pessoal vai
+    // para o GA4: serviços são slugs e e-mail/mensagem viram apenas booleanos.
+    const leadEventParams = {
+        lead_source: 'contact_form',
+        services: selectedServiceSlugs.join(','),
+        services_count: selectedServices.length,
+        neighborhood: formData.neighborhood,
+        has_email: !!formData.email,
+        has_message: !!messageText
+    };
+    trackGA4Event('lead_submit_attempt', leadEventParams);
     
     // Show loading state (use ButtonLoader if available)
     if (typeof ButtonLoader !== 'undefined') {
@@ -847,12 +875,7 @@ async function handleFormSubmit(event) {
     
     try {
         // Send to API. deliverLead NUNCA lança: as três saídas possíveis
-        // (success / error / fetch_error) são tratadas no mesmo lugar, o que garante
-        // que `generate_lead` sai em TODAS elas. Antes, o evento de conversão estava
-        // dentro do `try` junto do fetch: quando o fetch lançava (offline, DNS, CORS,
-        // timeout, servidor inalcançável) o código pulava direto para o `catch`, abria
-        // o WhatsApp com nome, telefone, bairro e serviços — o lead chegava na loja — e
-        // o GA4 não contava conversão nenhuma.
+        // (success / error / fetch_error) são tratadas no mesmo lugar.
         const result = await deliverLead(formData, LEAD_FOREGROUND_ATTEMPTS);
         const apiSuccess = result.status === 'success';
 
@@ -867,24 +890,16 @@ async function handleFormSubmit(event) {
             trackFormInteraction('submit_success', 'all_fields', '', apiSuccess ? 'API success' : 'API failed');
         }
 
-        // Track as conversion with services and neighborhood.
-        //
-        // `services` vai em slug e não no rótulo: a lista dos 8 rótulos tem 127
-        // caracteres, acima do limite de 100 por valor de parâmetro do GA4, e chegava
-        // truncada — justamente na seleção maior, que é o lead mais valioso.
-        // `api_status` distingue os três desfechos, então o relatório separa
-        // "servidor respondeu erro" de "requisição nem chegou" sem perder a contagem.
-        trackGA4Event('generate_lead', {
-            lead_source: 'contact_form',
-            services: selectedServiceSlugs.join(','),
-            services_count: selectedServices.length,
-            neighborhood: formData.neighborhood,
-            api_status: result.status,
-            delivery_attempts: result.attempts,
-            lead_queued: queued,
-            has_email: !!formData.email,
-            has_message: !!messageText
-        });
+        // Conversão só existe quando a API confirmou que aceitou o lead. Falhas já
+        // têm lead_submit_attempt como denominador; se a fila entregar depois, o
+        // evento distinto lead_recovered registra esse desfecho.
+        if (apiSuccess) {
+            trackGA4Event('generate_lead', {
+                ...leadEventParams,
+                api_status: 'success',
+                delivery_attempts: result.attempts
+            });
+        }
 
         // Track Google Ads conversion
         if (typeof gtag !== 'undefined' && apiSuccess) {
@@ -943,18 +958,14 @@ async function handleFormSubmit(event) {
             const encodedMessage = encodeURIComponent(whatsappMessage);
             const whatsappURL = `https://wa.me/5521987926578?text=${encodedMessage}`;
 
-            showAlert(queued
-                ? '⚠️ <strong>Sem conexão para enviar agora.</strong><br>Seu pedido ficou salvo e será reenviado sozinho quando a internet voltar. Você será redirecionado para o WhatsApp para adiantar o contato.'
-                : '⚠️ <strong>Problema no envio automático.</strong><br>Você será redirecionado para o WhatsApp para finalizar o contato.', 'error');
-
-            // `form_fallback` = servidor respondeu erro; `form_error` = requisição não
-            // chegou. Os dois valores são os que o site já emitia nesses dois caminhos.
-            trackWhatsAppClick(result.status === 'fetch_error' ? 'form_error' : 'form_fallback', whatsappMessage);
-
-            // Redirect to WhatsApp after 2 seconds
-            setTimeout(() => {
-                window.open(whatsappURL, '_blank');
-            }, 2000);
+            const handoffContext = result.status === 'fetch_error' ? 'form_error' : 'form_fallback';
+            showWhatsAppHandoff(
+                queued
+                    ? 'Sem conexão para enviar agora. Seu pedido ficou salvo e será reenviado quando a internet voltar.'
+                    : 'Problema no envio automático. Finalize o contato pelo WhatsApp.',
+                whatsappURL,
+                handoffContext
+            );
         }
     } finally {
         // Reset button state (use ButtonLoader if available)
@@ -1138,18 +1149,22 @@ function initCompleteAnalytics() {
         });
     });
     
-    // Track form field interactions
+    // Track form field interactions. Uma única flag é compartilhada por todos os
+    // campos e pelo grupo de serviços: start significa "este formulário começou",
+    // não "este campo foi focado pela primeira vez".
+    let formStarted = false;
+    const trackFormStart = fieldName => {
+        if (formStarted) return;
+        formStarted = true;
+        trackFormInteraction('start', fieldName);
+    };
+
     const formFields = ['name', 'phone', 'email', 'neighborhood', 'message'];
     formFields.forEach(fieldId => {
         const field = document.getElementById(fieldId);
         if (field) {
-            // Track first focus (form start)
-            let firstFocus = true;
             field.addEventListener('focus', () => {
-                if (firstFocus) {
-                    trackFormInteraction('start', fieldId);
-                    firstFocus = false;
-                }
+                trackFormStart(fieldId);
                 trackFormInteraction('field_focus', fieldId);
             });
             
@@ -1172,15 +1187,10 @@ function initCompleteAnalytics() {
     // continuar no mesmo campo, não sair e voltar — contar isso inflaria `field_focus`
     // em até 8x contra os outros campos e a comparação do funil perderia sentido.
     const staysInServicesGroup = related => !!related && related.name === 'services';
-    let servicesFirstFocus = true;
-
     document.querySelectorAll('input[name="services"]').forEach(checkbox => {
         checkbox.addEventListener('focus', (e) => {
             if (staysInServicesGroup(e.relatedTarget)) return;
-            if (servicesFirstFocus) {
-                trackFormInteraction('start', 'services');
-                servicesFirstFocus = false;
-            }
+            trackFormStart('services');
             trackFormInteraction('field_focus', 'services');
         });
 

--- a/public/js/whatsapp-cta.js
+++ b/public/js/whatsapp-cta.js
@@ -362,6 +362,8 @@ const WhatsAppCTA = {
      * três também saíram dos eventos abaixo: eram cópia do que o GA4 mede sozinho.
      */
     trackConversions() {
+        const whatsappSelector = 'a[href*="whatsapp"], a[href*="wa.me"]';
+
         /**
          * ÚNICO emissor de whatsapp_click do site. O app.js também ligava um ouvinte em
          * cada `a[href*="wa.me"]`, então um clique saía como DOIS whatsapp_click com
@@ -375,7 +377,7 @@ const WhatsAppCTA = {
          * calculava — nada se perde na consolidação.
          */
         document.addEventListener('click', (e) => {
-            const target = e.target.closest('a[href*="whatsapp"], a[href*="wa.me"]');
+            const target = e.target.closest(whatsappSelector);
 
             if (target) {
                 const context = target.dataset.context || 'unknown';
@@ -394,6 +396,98 @@ const WhatsAppCTA = {
                 ctaLog(`📊 WhatsApp click tracked: ${context} (${clickSource})`);
             }
         });
+
+        /**
+         * Denominador dos cliques: uma impressão por contexto por pageview.
+         *
+         * IntersectionObserver mantém o custo fora do scroll handler. A checagem de
+         * estilo evita contar a sticky enquanto está recolhida e o flutuante enquanto
+         * `.is-hidden`. O MutationObserver só cobre dois casos que não exigem nova
+         * interseção geométrica: mudança de visibilidade por classe e o handoff do
+         * formulário, que é criado depois do carregamento.
+         */
+        if ('IntersectionObserver' in window) {
+            const impressedContexts = new Set();
+            const intersectingLinks = new WeakSet();
+            const observedLinks = new WeakSet();
+
+            const clickSourceFor = target => target.classList.contains('whatsapp-float')
+                ? 'floating_button'
+                : target.closest('.hero')
+                    ? 'hero_cta'
+                    : 'inline_button';
+
+            const isRendered = target => {
+                const style = window.getComputedStyle(target);
+                if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0) {
+                    return false;
+                }
+
+                const hiddenContainer = target.closest('[aria-hidden="true"], .whatsapp-sticky-cta:not(.active)');
+                return !hiddenContainer;
+            };
+
+            const trackImpression = target => {
+                if (!intersectingLinks.has(target) || !isRendered(target)) return;
+
+                const context = target.dataset.context || 'unknown';
+                if (impressedContexts.has(context)) return;
+                impressedContexts.add(context);
+
+                ctaTrack('whatsapp_impression', {
+                    context,
+                    click_source: clickSourceFor(target),
+                    button_text: target.textContent.trim()
+                });
+                ctaLog(`📊 WhatsApp impression tracked: ${context}`);
+            };
+
+            const impressionObserver = new IntersectionObserver((entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting && entry.intersectionRatio > 0) {
+                        intersectingLinks.add(entry.target);
+                        trackImpression(entry.target);
+                    } else {
+                        intersectingLinks.delete(entry.target);
+                    }
+                });
+            }, { threshold: 0.01 });
+
+            const observeLink = target => {
+                if (observedLinks.has(target)) return;
+                observedLinks.add(target);
+                impressionObserver.observe(target);
+            };
+
+            const observeLinksWithin = node => {
+                if (!(node instanceof Element)) return;
+                if (node.matches(whatsappSelector)) observeLink(node);
+                node.querySelectorAll(whatsappSelector).forEach(observeLink);
+            };
+
+            document.querySelectorAll(whatsappSelector).forEach(observeLink);
+
+            new MutationObserver((mutations) => {
+                mutations.forEach(mutation => {
+                    if (mutation.type === 'childList') {
+                        mutation.addedNodes.forEach(observeLinksWithin);
+                        return;
+                    }
+
+                    const target = mutation.target;
+                    if (target.matches('.whatsapp-float')) trackImpression(target);
+                    if (target.matches('.whatsapp-sticky-cta')) {
+                        const stickyLink = target.querySelector(whatsappSelector);
+                        if (stickyLink) trackImpression(stickyLink);
+                    }
+                });
+            }).observe(document.body, {
+                childList: true,
+                subtree: true,
+                attributes: true,
+                attributeFilter: ['class', 'aria-hidden']
+            });
+        }
 
         // Rastrear cliques em links com data-track (endereço, email)
         document.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary

- Make `form_interaction` / `form_action=start` fire once per form per pageview instead of once per field.
- Add `lead_submit_attempt` as the valid-payload delivery denominator and emit `generate_lead` only after a confirmed API `2xx`; keep queue acceptance distinct as `lead_recovered`.
- Replace the timed WhatsApp popup with a real handoff link, so `whatsapp_click` requires an actual click.
- Add `whatsapp_impression`, once per pageview per `context`, using `IntersectionObserver` plus visibility checks so CTA click rates have an exposure denominator.
- Update the analytics contract and reporting guidance. No PII is sent in the new events.

## Event contract

- New: `lead_submit_attempt` — valid payload is about to be delivered.
- Retained with narrower semantics: `generate_lead` — foreground API acceptance only. This is the event that should be imported into Google Ads because it now means a lead exists; the empty Ads label guard remains unchanged.
- Retained: `lead_recovered` — queued delivery accepted later, reported distinctly.
- Retained with narrower semantics: `whatsapp_click` — actual click on a WhatsApp link, including `form_fallback` / `form_error` handoffs.
- New: `whatsapp_impression` — first genuine visibility per `context` per pageview.
- Retained with corrected cardinality: `form_interaction` + `form_action=start` — once per form/pageview.

No event was renamed. Two synthetic emitters were retired: `generate_lead` on HTTP/network failure and `whatsapp_click` before timed `window.open`. This creates a reporting seam with data collected since roughly 2026-08-10: pre-deploy `generate_lead`, `whatsapp_click`, and form-start counts are not directly comparable to post-deploy counts. Custom-dimension registration is not retroactive.

## Built-output browser proof

Served `dist/` at `http://127.0.0.1:4173`, captured `dataLayer` events in headless Chrome, and drove the rendered form/CTAs.

1. Focused name, phone, and email, then abandoned:
```text
form_interaction { form_action: start, field_name: name }
```
Count: exactly 1.

2. Submitted to a `201` stub:
```text
lead_submit_attempt { services_count: 0, has_email: false, has_message: false }
generate_lead { services_count: 0, api_status: success, delivery_attempts: 1 }
```
Count and order: exactly one attempt, then exactly one confirmed lead.

3. Submitted to a `503` stub, before clicking the rendered fallback:
```text
lead_submit_attempt { services_count: 0, has_email: false, has_message: false }
```
`generate_lead`: 0. `whatsapp_click` with `context=form_fallback`: 0.

4. Clicked the real `Continuar no WhatsApp` fallback link:
```text
whatsapp_click { context: form_fallback, click_source: inline_button, button_text: Continuar no WhatsApp }
```
Count: exactly 1.

5. Scrolled to reveal the sticky CTA, returned to the top, and repeated:
```text
whatsapp_impression { context: hero-whatsapp, click_source: hero_cta }
whatsapp_impression { context: sticky-cta, click_source: inline_button }
```
Count after repeated scrolling: exactly 1 for each context.

The captured analytics parameters contained no name, phone, email, message, or hashes of those values.

## Verification

- [x] `npm ci && npm run build`
- [x] Production output contains the updated scripts and preserves file-format routes
- [x] Browser proof against `dist/` passed all five scenarios above
- [x] `node --check public/js/app.js`
- [x] `node --check public/js/whatsapp-cta.js`
- [x] `git diff --check`

Not verified: live GA4 delivery/reporting, custom-dimension registration, and Google Ads import because those require the owner's analytics accounts and post-deploy traffic.

Made with [Cursor](https://cursor.com)