### PR TITLE
Close the WhatsApp contrast guard blind spot

### DIFF
--- a/scripts/check-contrast.mjs
+++ b/scripts/check-contrast.mjs
@@ -4,14 +4,28 @@
 // do site era o de rótulo menos legível, e nada no processo pegava isso.
 // Lê os tokens direto do CSS, então não há uma segunda fonte de verdade para
 // desatualizar.
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-// Os tokens vivem no index-inline.css; whatsapp-cta.css entra na leitura porque os
-// componentes de lá (barra sticky, botão do card de serviço) fixavam o verde em hex e
-// escapavam desta verificação por isso mesmo — o rótulo saía com 1,98:1 e o CI passava
-// verde. Agora eles consomem os tokens, e um hex solto neles é pego abaixo.
-const CSS = ['../src/styles/index-inline.css', '../src/styles/whatsapp-cta.css']
-  .map((path) => readFileSync(new URL(path, import.meta.url), 'utf8'))
+// Os tokens e o guard de literais cobrem todo stylesheet sob src/styles/. A lista vem
+// do diretório para que um arquivo CSS novo entre na verificação sem alterar o script.
+const ROOT = fileURLToPath(new URL('../', import.meta.url));
+const STYLES_DIR = join(ROOT, 'src/styles');
+const findStylesheets = (directory) =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(directory, entry.name);
+    if (entry.isDirectory()) return findStylesheets(fullPath);
+    if (!entry.isFile() || !entry.name.endsWith('.css')) return [];
+    return [{
+      path: relative(ROOT, fullPath),
+      content: readFileSync(fullPath, 'utf8'),
+    }];
+  });
+const STYLESHEETS = findStylesheets(STYLES_DIR)
+  .sort((a, b) => a.path.localeCompare(b.path));
+const CSS = STYLESHEETS
+  .map(({ content }) => content)
   .join('\n');
 
 const tokens = Object.fromEntries(
@@ -84,21 +98,29 @@ if (pop < POP_MIN) failed++;
 // componentes escreveram o verde da marca em hex, então nenhum par aqui os descrevia e o
 // CI passava verde com um rótulo de 1,98:1 no ar. Este guard fecha essa porta.
 const WHATSAPP_LITERALS = /#25d366|#128c7e/gi;
-const COMPONENTES = readFileSync(new URL('../src/styles/whatsapp-cta.css', import.meta.url), 'utf8')
-  // Sem os comentários: eles CITAM os hex antigos para registrar por que saíram, e um
-  // guard que proíbe explicar o defeito empurra a explicação para fora do arquivo.
-  .replace(/\/\*[\s\S]*?\*\//g, '');
-const literais = [...COMPONENTES.matchAll(WHATSAPP_LITERALS)].map((m) => m[0]);
+const violations = STYLESHEETS.flatMap(({ path, content }) => {
+  const declarations = content
+    // Sem os comentários: eles CITAM os hex antigos para registrar por que saíram, e um
+    // guard que proíbe explicar o defeito empurra a explicação para fora do arquivo.
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    // A declaração do próprio token é a fonte de verdade, não um uso que a contorna.
+    .replace(/--whatsapp:\s*[^;]+;/gi, '');
+  const literals = [...declarations.matchAll(WHATSAPP_LITERALS)].map((m) => m[0]);
+  return literals.length ? [{ path, literals: [...new Set(literals)] }] : [];
+});
 // rgba() de sombra é aceitável — cor de sombra não é par texto/fundo. Hex é que não.
-if (literais.length) {
+if (violations.length) {
+  const details = violations
+    .map(({ path, literals }) => `  ${path}: ${literals.join(', ')}`)
+    .join('\n');
   console.error(
-    `\n✗ whatsapp-cta.css escreve o verde da marca em hex (${[...new Set(literais)].join(', ')}).` +
+    `\n✗ Stylesheet escreve o verde da marca em hex:\n${details}` +
       `\n  Use var(--whatsapp) / var(--whatsapp-dark) com var(--whatsapp-text), senão o par` +
       `\n  texto/fundo fica fora desta verificação — foi assim que 1,98:1 chegou à produção.`
   );
   failed++;
 } else {
-  console.log('\n✓ Nenhum verde de marca em hex nos componentes de CTA');
+  console.log('\n✓ Nenhum verde de marca em hex nos stylesheets');
 }
 
 if (failed) {

--- a/src/styles/index-inline.css
+++ b/src/styles/index-inline.css
@@ -776,12 +776,12 @@
             right: var(--float-inset);
             width: var(--float-size);
             height: var(--float-size);
-            background: #25d366;
+            background: var(--whatsapp);
             border-radius: 50%;
             display: flex;
             align-items: center;
             justify-content: center;
-            color: var(--white);
+            color: var(--whatsapp-text);
             font-size: 2rem;
             box-shadow: var(--shadow-xl);
             z-index: 999;
@@ -793,7 +793,7 @@
 
         .whatsapp-float:hover {
             transform: scale(1.1);
-            background: #20ba5a;
+            background: var(--whatsapp-dark);
         }
 
         /* Footer */

--- a/src/styles/whatsapp-cta.css
+++ b/src/styles/whatsapp-cta.css
@@ -363,7 +363,7 @@
 
 /* Phone Link no Footer */
 .footer-contact-link.phone-link:hover {
-    color: #4CAF50 !important;
+    color: var(--white) !important;
 }
 
 /* Address Link no Footer */
@@ -373,7 +373,7 @@
 }
 
 .footer-contact-link.address-link:hover {
-    color: #FF5722 !important;
+    color: var(--white) !important;
 }
 
 /* Ícones do footer com espaçamento */


### PR DESCRIPTION
## Summary
- use the semantic WhatsApp background, text, and hover tokens on the persistent floating button
- return phone and address footer hovers to the documented white footer color while keeping green exclusive to WhatsApp
- discover every stylesheet under `src/styles/` recursively so future CSS files cannot bypass the brand-green literal guard

## Contrast proof
Measured with:

```sh
node --input-type=module -e 'const s=c=>c/255<=.03928?c/255/12.92:((c/255+.055)/1.055)**2.4;const l=h=>.2126*s(parseInt(h.slice(1,3),16))+.7152*s(parseInt(h.slice(3,5),16))+.0722*s(parseInt(h.slice(5,7),16));const r=(a,b)=>{const[x,y]=[l(a),l(b)].sort((p,q)=>q-p);return(x+.05)/(y+.05)};for(const [label,a,b] of [["white on #25d366","#ffffff","#25d366"],["white on #20ba5a","#ffffff","#20ba5a"],["--whatsapp-text on --whatsapp","#1f2937","#25d366"]]) console.log(`${label}: ${r(a,b).toFixed(2)}:1`)'
```

- before: white on `#25d366` = **1.98:1**
- before hover: white on `#20ba5a` = **2.55:1**
- after: `--whatsapp-text` on `--whatsapp` = **7.40:1**

## Visual proof — built output at 390×844
| Before | After |
| --- | --- |
| ![Floating WhatsApp button before: white glyph on green](https://github.com/user-attachments/assets/64776224-fd75-4cdd-b733-27d998129d4a) | ![Floating WhatsApp button after: dark glyph on green](https://github.com/user-attachments/assets/910bfe4d-2fd7-4dbb-a84d-f27704add4a7) |

Chrome headless rendered `dist/index.html`; the validated viewport reported `innerWidth=390`, `innerHeight=844`, and `scrollWidth=390`.

## Guard failure proof
I temporarily changed the floating button background back to the literal brand green and ran `npm run build`. The build exited 1 and named the stylesheet:

```text
✗ Stylesheet escreve o verde da marca em hex:
  src/styles/index-inline.css: #25d366
  Use var(--whatsapp) / var(--whatsapp-dark) com var(--whatsapp-text), senão o par
  texto/fundo fica fora desta verificação — foi assim que 1,98:1 chegou à produção.

1 verificação(ões) de contraste falharam.
```

I then restored the token usage and reran the clean build.

## Test plan
- [x] `npm ci && npm run build` — passed; contrast gate passed and 17 static pages were generated
- [x] deliberate literal injection — failed with `src/styles/index-inline.css` in the error
- [x] before/after Chrome screenshots from built output at a validated 390×844 viewport
- [x] `git diff -U0 | rg '^\\+.*#[0-9a-fA-F]{3,8}'` — no added hex colors

Everything requested was verified; no known verification gaps remain.

Made with [Cursor](https://cursor.com)