### PR TITLE
Yield sticky CTA to visible conversion regions

### DIFF
--- a/public/js/whatsapp-cta.js
+++ b/public/js/whatsapp-cta.js
@@ -254,23 +254,55 @@ const WhatsAppCTA = {
         
         document.body.appendChild(stickyBar);
         
-        // Mostrar/esconder baseado em scroll
+        // A sticky cede espaço aos pontos de conversão que já estão na tela. O Set
+        // cobre a transição direta entre regiões sem reexibir a barra entre callbacks.
+        const yieldingRegions = document.querySelectorAll('.cta-band, #contato');
+        const intersectingRegions = new Set();
         let lastScroll = 0;
+        let scrollingDown = false;
+
+        const scrollPercent = () =>
+            (window.scrollY / (document.documentElement.scrollHeight - window.innerHeight)) * 100;
+
+        const syncSticky = () => {
+            this.floatState.stickyVisible = stickyBar.classList.contains('active');
+            this.syncFloat();
+        };
+
+        if (yieldingRegions.length && 'IntersectionObserver' in window) {
+            const regionObserver = new IntersectionObserver((entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) intersectingRegions.add(entry.target);
+                    else intersectingRegions.delete(entry.target);
+                });
+
+                if (intersectingRegions.size) {
+                    stickyBar.classList.remove('active');
+                } else if (scrollingDown && scrollPercent() > 30) {
+                    stickyBar.classList.add('active');
+                }
+                syncSticky();
+            }, { threshold: 0 });
+
+            yieldingRegions.forEach(region => regionObserver.observe(region));
+        }
+
+        // Mostrar/esconder baseado em scroll
         window.addEventListener('scroll', () => {
-            const scrollPercent = (window.scrollY / (document.documentElement.scrollHeight - window.innerHeight)) * 100;
+            const currentScrollPercent = scrollPercent();
             const currentScroll = window.scrollY;
+            scrollingDown = currentScroll > lastScroll;
             
             // Mostrar após 30% de scroll e quando scrollando para baixo
-            if (scrollPercent > 30 && currentScroll > lastScroll) {
+            if (currentScrollPercent > 30 && scrollingDown && !intersectingRegions.size) {
                 stickyBar.classList.add('active');
-            } else if (currentScroll < lastScroll && scrollPercent < 20) {
+            } else if (currentScroll < lastScroll && currentScrollPercent < 20) {
                 // Esconder quando volta ao topo
                 stickyBar.classList.remove('active');
             }
 
             // A sticky e o flutuante são o mesmo CTA: quando ela aparece, ele sai.
-            this.floatState.stickyVisible = stickyBar.classList.contains('active');
-            this.syncFloat();
+            syncSticky();
 
             lastScroll = currentScroll;
         });


### PR DESCRIPTION
## Summary
- Observe `.cta-band` and `#contato` with `IntersectionObserver` so the sticky WhatsApp bar yields whenever another conversion region is visible.
- Restore the sticky after a downward exit past the existing 30% threshold and preserve the sticky-to-floating-button handoff.
- Track intersecting regions as a set, so missing regions and direct transitions between regions do not throw or briefly re-show the bar.

## Verification
- `npm ci && npm run build` passed: contrast checks passed and Astro generated 17 pages, including all 11 neighborhood routes as `.html` files.
- `node --check public/js/whatsapp-cta.js` passed.
- A real 390x844 Chrome/CDP run against `dist/` produced these transition assertions:

```text
PASS home CTA band y=2800 active=false floatHidden=true
PASS home after CTA band y=3300 active=true floatHidden=true
PASS home testimonials y=3800 active=true floatHidden=true
PASS home form y=5000 active=false floatHidden=true
PASS Realengo form y=2400 active=false floatHidden=true
PASS Realengo after form y=3600 active=true floatHidden=true
```

Realengo has no `.cta-band` (`querySelector('.cta-band')` returned `null`); its `#contato` observer still worked without errors.

## Screenshot proof
The screenshots were produced from the built site and kept under the explicitly excluded `_evidence/p2-sticky-after/` directory. Exact captured states:

| Screenshot | Viewport / scroll position | Result |
| --- | --- | --- |
| `home-cta-band.png` | 390x1200, y=2146 | CTA band intersects; sticky absent; amber action unobstructed |
| `home-mid-testimonials.png` | 390x844, y=3932 | Sticky returned after the CTA band and is useful during testimonials; float hidden |
| `home-form.png` | 390x844, y=4865 | Form intersects; sticky absent; amber submit unobstructed |
| `realengo-form.png` | 390x844, y=2134 | Neighborhood form intersects; sticky absent |
| `realengo-mid-faq.png` | 390x844, y=4082 | Sticky returned after the neighborhood form; float hidden |

Chrome's direct deep-fragment capture painted blank on this macOS build, so a temporary, uncommitted same-origin iframe in `dist/proof-scroll.html` kept the outer capture surface at y=0 while the built page navigated to each real section. No source or rendered page markup was changed for the captures.

```sh
python3 -m http.server 4174 --directory "dist"

"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless --disable-gpu --timeout=3000 --screenshot="_evidence/p2-sticky-after/home-cta-band.png" --window-size=390,1200 "http://127.0.0.1:4174/proof-scroll.html?case=home-band-gallery&page=%2Findex.html%3Fproof%3Dgallery%23trabalhos"

"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless --disable-gpu --timeout=3000 --screenshot="_evidence/p2-sticky-after/home-mid-testimonials.png" --window-size=390,844 "http://127.0.0.1:4174/proof-scroll.html?case=home-mid&page=%2Findex.html%3Fproof%3Dmid%23depoimentos"

"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless --disable-gpu --timeout=3000 --screenshot="_evidence/p2-sticky-after/home-form.png" --window-size=390,844 "http://127.0.0.1:4174/proof-scroll.html?case=home-form-anchor&page=%2Findex.html%3Fproof%3Danchor%23contato"

"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless --disable-gpu --timeout=3000 --screenshot="_evidence/p2-sticky-after/realengo-form.png" --window-size=390,844 "http://127.0.0.1:4174/proof-scroll.html?case=realengo-form&page=%2Frealengo.html%3Fproof%3Dform%23contato"

"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless --disable-gpu --timeout=3000 --screenshot="_evidence/p2-sticky-after/realengo-mid-faq.png" --window-size=390,844 "http://127.0.0.1:4174/proof-scroll.html?case=realengo-mid&page=%2Frealengo.html%3Fproof%3Dmid%23faq"
```

## Expected analytics impact
`whatsapp_click` events with the `sticky` context will decrease because the sticky bar is intentionally exposed for less time. That is the intended outcome of removing CTA competition, not a tracking regression.

Made with [Cursor](https://cursor.com)