### PR TITLE
Unify WhatsApp service analytics taxonomy

### DIFF
--- a/docs/ANALYTICS_PLAN.md
+++ b/docs/ANALYTICS_PLAN.md
@@ -7,11 +7,10 @@ Este documento é para executar com o painel do GA4 aberto. Ele descreve o **est
 da instrumentação (page_view único, `page_type`/`neighborhood_page` em todo evento,
 sem `timestamp`), não o estado atual em produção.
 
-Complementa `GA4_TRACKING_GUIDE.md`, que lista os eventos mas não trata de registro de
-dimensão nem de leitura — e é justamente o registro que hoje bloqueia todo insight:
-**parâmetro não registrado é invisível em relatório**.
+`GA4_TRACKING_GUIDE.md` é o contrato operacional resumido; este plano detalha registro e
+leitura. **Parâmetro não registrado é invisível em relatório**.
 
-**Execute nesta ordem:** registrar as 15 dimensões (§2, ~15 min) → retenção 14 meses (§2)
+**Execute nesta ordem:** registrar as 14 dimensões (§2, ~15 min) → retenção 14 meses (§2)
 → marcar `generate_lead` como evento-chave (§3) → esperar dados → montar funil (§4) e as
 4 explorações (§5) → religar o Ads por importação (§7). Antes de concluir qualquer coisa,
 ler §6.
@@ -27,16 +26,16 @@ log aparece, e não há evento que escape da segmentação.
 
 | Evento | Arquivo:linha | Quando dispara | Parâmetros próprios (exemplo) | Cardinalidade |
 |---|---|---|---|---|
-| `page_view` | `Base.astro:113` | 1x por carregamento (`send_page_view: true`) | automáticos: `page_location`, `page_title`, `page_referrer` | baixa — 14 URLs (`/`, 11 `/<bairro>.html`, `/blog.html`, `/obrigado.html`) mais `/404.html` e `/500.html` |
+| `page_view` | `Base.astro` | 1x por carregamento (`send_page_view: true`) | automáticos: `page_location`, `page_title`, `page_referrer` | baixa — 17 URLs: home, 11 bairros, avaliação, blog, obrigado, 404 e 500 |
 | `session_start`, `first_visit`, `user_engagement` | GA4 automático | início de sessão / 1ª visita | — | — |
 | `scroll_depth` | `app.js` | cruza 25 / 50 / 75 / 100% | `percent_scrolled: 50`, `page_height: 9840`, `viewport_height: 844` | `percent_scrolled` baixa (4); `page_height`/`viewport_height` altas (numéricas). **Nome próprio para não colidir com o `scroll` automático do GA4, que dispara a 90%** |
-| `section_view` | `app.js:103` ← `:672` | 50% da seção visível, 1x por seção por pageview | `section_name: "Nossos Serviços"`, `section_id: "servicos"`, `scroll_position: 2140`, `time_on_page: 18` | `section_id` baixa (`servicos`, `diferenciais`, `depoimentos`, `contato`, `faq`); `section_name` instável (vem do `<h2>`); `scroll_position`/`time_on_page` altas |
+| `section_view` | `app.js` | 50% da seção visível, 1x por seção por pageview | `section_name: "Nossos Serviços"`, `section_id: "servicos"`, `scroll_position: 2140`, `time_on_page: 18` | `section_id` baixa (`servicos`, `trabalhos`, `diferenciais`, `depoimentos`, `contato`, `faq`); `section_name` instável (vem do `<h2>`); `scroll_position`/`time_on_page` altas |
 | `cta_click` | `app.js:63` ← `:710` | clique em `.btn-primary` / `.btn-success` / `.btn-secondary` | `button_text: "Solicitar Orçamento Grátis"`, `button_location: "hero"` (`hero`\|`menu`\|`contact_form`\|`other`), `target_section: "#contato"`, `click_position_y: 0` | `button_text`/`button_location` baixas; `click_position_y` alta |
-| `service_interaction` | `app.js:115` ← `:724` | clique em qualquer ponto de `.service-card` | `service_name: "Box para Banheiro"`, `service_position: 1`, `interaction_type: "click"` | baixa (6 cards) |
+| `service_interaction` | `app.js` | clique em qualquer ponto de `.service-card` | `service_name: "Box para Banheiro"`, `service_position: 1`, `interaction_type: "click"` | inclui os 6 cards da home, os 6 serviços e os 5 motivos de cada bairro; não usar como ranking até restringir o seletor em tarefa própria |
 | `navigation_click` | `app.js:147` ← `:623`, `:732`, `:741`, `:825` | `.nav-link`, links do rodapé, âncoras `#`, toggle do menu mobile | `link_text: "Serviços"`, `link_target: "#servicos"`, `navigation_type: "menu"` (`menu`\|`footer`\|`internal_link`\|`mobile_menu_toggle`) | média (~30 combinações de texto/alvo) |
 | `phone_click` | `app.js:136` ← `:750` | clique em `a[href^="tel:"]` | `phone_number: "+552134216066"` (número **da loja**), `click_location: "footer"` | baixa |
-| `whatsapp_impression` | `whatsapp-cta.js` (`IntersectionObserver`) | CTA de WhatsApp fica realmente visível — **1x por `context` por pageview** | `context: "service-sacada"`, `click_source`, `button_text: "Pedir Orçamento"` | mesma cardinalidade baixa de `context`; é o denominador de §5.4 |
-| `whatsapp_click` | `whatsapp-cta.js` (listener delegado no `document`) | clique real em qualquer link de WhatsApp — **um** por clique | `context: "service-sacada"`, `click_source`, `button_text: "Pedir Orçamento"` | `context` baixa (inclui `form_fallback`/`form_error`; ver §5.4) |
+| `whatsapp_impression` | `whatsapp-cta.js` (`IntersectionObserver`) | CTA fica realmente visível — **1x por combinação `context` + `service` por pageview** | `context: "service-card"`, `service: "guarda-corpo"`, `click_source`, `button_text` | `context` identifica origem; `service` identifica o serviço canônico |
+| `whatsapp_click` | `whatsapp-cta.js` (listener delegado no `document`) | clique real em qualquer link de WhatsApp — **um** por clique | os mesmos parâmetros da impressão | `context` não incorpora mais serviço; handoffs são `form-fallback`/`form-error` |
 | `contact_link_click` | `whatsapp-cta.js` | clique em `[data-track]` — **2** links do rodapé, e-mail e endereço (`Footer.astro:78,84`); WhatsApp e telefone saem como os próprios eventos | `link_id: "footer_email_click"`, `link_type: "mailto"`, `link_text` | baixa (2) |
 | `form_interaction` | `app.js:84` | 10 gatilhos, ver tabela abaixo | `form_name: "contact_form"`, `form_action: "field_focus"`, `field_name: "phone"`, `field_value_length: 15` (só quando há valor), `error_message: "Telefone inválido…"` (só em erro) | `form_action` baixa (10); `field_name` baixa (7: `name`, `phone`, `email`, `neighborhood`, `message`, `services`, `all_fields`) |
 | `engagement_milestone` | `app.js:158` ← `:696` | 30s / 60s / 120s após `DOMContentLoaded` | `milestone_name: "time_60s"`, `milestone_value: 60` | baixa (3) |
@@ -48,6 +47,7 @@ log aparece, e não há evento que escape da segmentação.
 | `review_submitted` | `avaliar.astro` | 202 do `POST /reviews` | `rating: 5`, `photo_count: 3`, `photo_failures: 0`, `has_comment: true` | `rating` baixa; as contagens são numéricas |
 | `review_failed` | `avaliar.astro` | erro da API ou de rede no envio | `error_message: "Link expirado"` | baixa |
 | `review_link_invalid` | `avaliar.astro` | `?t=` ausente ou fora do formato | — | — |
+| `review_validation_error` | `avaliar.astro` | tentativa de envio sem nota | `error_message` | baixa |
 
 Os quatro últimos só acontecem em `page_type = avaliar`, e essa página é `noindex`:
 tráfego dela vem de link em conversa, nunca de busca. **A leitura que eles habilitam é
@@ -64,12 +64,12 @@ Valores de `form_action`, com a linha que os emite:
 | `field_focus` | `app.js:789` | **todo** focus, não só o primeiro — contagem infla por pessoa |
 | `field_blur` | `app.js:794` | passa o valor; sai só `field_value_length` |
 | `field_complete` | `app.js:359` | campo válido e preenchido |
-| `validation_error` | `app.js:349`, `:387` | `:387` é o bloco de serviços (`error_message: "Nenhum serviço selecionado"`) |
+| `validation_error` | `app.js` | campo obrigatório ou formato inválido; serviços são opcionais e não emitem este erro |
 | `service_selected` | `app.js` | dispara a cada marcação; `field_name` é sempre `services` |
 | `submit_attempt` | `app.js:410` | antes de validar |
 | `validation_failed` | `app.js:445` | submit barrado na validação |
-| `submit_success` | `app.js:505` | dispara também quando a API falhou (`error_message: "API failed"`) |
-| `submit_error` | `app.js:577` | exceção de rede |
+| `submit_success` | `app.js` | tentativa HTTP concluída; use `generate_lead` para aceite real |
+| `submit_error` | `app.js` | falha de rede |
 
 Campos que emitem `field_focus`: `name`, `phone`, `email`, `neighborhood`, `message` e
 **`services`** — o bloco dos 8 checkboxes conta como UM campo, e o vaivém entre checkboxes
@@ -99,7 +99,8 @@ de evento; a lista usa 15.
 | `neighborhood_page` | Evento | bairro da **página** (origem do tráfego) | §5.1 (numerador e denominador) |
 | `neighborhood` | Evento | bairro **declarado no formulário** — pode divergir da página | §5.1 (tabela C) |
 | `services` | Evento | único registro do que o lead pediu | §5.2 (via filtro "contém") |
-| `context` | Evento | identidade do CTA de WhatsApp | §5.4 |
+| `context` | Evento | origem estável do CTA de WhatsApp | §5.4 |
+| `service` | Evento | slug canônico do serviço, independente da origem card/galeria/bairro | §5.2 e §5.4 |
 | `click_source` | Evento | categoria de origem de `whatsapp_click` e `whatsapp_impression` | §5.4 |
 | `form_action` | Evento | etapa do formulário — sem ela o funil do form não existe | §4, §5.3 |
 | `field_name` | Evento | campo da etapa | §5.3 |
@@ -107,8 +108,6 @@ de evento; a lista usa 15.
 | `section_id` | Evento | seção vista, valor **estável** | §4 (etapa 2) |
 | `button_location` | Evento | onde estava o botão do `cta_click` | §4, §5.4 |
 | `button_text` | Evento | desambigua dois CTAs no mesmo `button_location` | §5.4 |
-| `service_name` | Evento | card de serviço clicado | §5.2 (sinal de interesse) |
-| `api_status` | Evento | confirma que `generate_lead` corresponde a aceitação da API | auditoria de conversão |
 | `rating` | Evento | nota da avaliação (1-5); é o que separa elogio de reclamação | §1, eventos `review_*` |
 
 **Zero dimensões de escopo de usuário.** Nada na instrumentação descreve atributo
@@ -121,7 +120,9 @@ Categoria do dispositivo / Navegador / SO); `timestamp` (será removido);
 `scroll_position`, `time_on_page`, `click_position_y`, `page_height`, `viewport_height`,
 `message_length`, `field_value_length`, `service_position`, `milestone_value` (numéricos —
 se algum dia precisar, é **métrica** personalizada, não dimensão); `section_name` (texto do
-`<h2>`: muda quando a copy muda e quebra o histórico — use `section_id`).
+`<h2>`: muda quando a copy muda e quebra o histórico — use `section_id`); `api_status`
+(constante em `generate_lead`); `service_name` (o seletor atual também inclui motivos dos
+bairros; aguarde a tarefa que restringirá `service_interaction`).
 
 Enquanto estiver no Administrador, faça também: **Exibição de dados → Retenção de dados →
 14 meses**. O padrão é 2 meses, e explorações não alcançam além da retenção.
@@ -174,7 +175,7 @@ Três avisos sobre este funil, todos verificados no código:
 - **Etapa 5 → 6 ainda pode perder gente.** `generate_lead` já significa API aceita, mas o
   redirecionamento espera 1200 ms; quem fecha a aba antes não gera o pageview de
   `/obrigado.html`.
-- **Etapa 4 não cobre os checkboxes.** Ver §5.3.
+- **Etapa 4 cobre os checkboxes.** O primeiro foco em `services` também inicia o formulário.
 
 ---
 
@@ -210,22 +211,23 @@ principais por sessão", que só existe depois de §3.
 
 - **Pergunta:** os 6 cards têm peso igual na página; têm peso igual na demanda?
 - **Tipo:** formato livre.
-- **Cardinalidade — leia antes de montar:** `services` é lista de **slugs**
-  (`box,sacada,guarda_corpo,portas_vidro,janelas_aluminio,espelhos,divisorias,tampos_mesa`).
+- **Cardinalidade — leia antes de montar:** `services` é lista deduplicada de **slugs
+  canônicos** (`box-banheiro`, `sacada`, `guarda-corpo`, `portas-janelas`, `espelho`,
+  `divisoria`, `tampo-mesa`). Mesmo com todas as opções, o valor fica abaixo do limite
+  de 100 caracteres do GA4.
   Continua sendo combinação, então detalhar por `services` dá uma tabela de combinações e
   não um ranking de serviços — mas já não estoura os 100 caracteres do GA4, que era o que
   cortava justamente a seleção maior, o lead mais valioso.
-- **Como montar:** uma consulta **por serviço**, 8 no total. Métrica: Contagem de eventos;
+- **Como montar:** uma consulta **por serviço**. Métrica: Contagem de eventos;
   filtros: Nome do evento exatamente `generate_lead` **e** `services` **contém** o *slug*
   (não o nome exibido). Os slugs foram escolhidos para que nenhum seja pedaço de outro, o
   que é o que torna o "contém" confiável. A soma das 8 passa do total de leads — esperado,
   cada linha é "% dos leads que citaram X", não uma partição.
   Atalho para ranking grosseiro sem 8 consultas: `services_count` responde "quantos
   serviços por lead", que é outra pergunta, mas de graça.
-- **Sinal de interesse (limpo, já disponível):** `service_interaction.service_name`
-  (cliques nos 6 cards) e `whatsapp_click` com `context` começando em `service-` — por
-  serviço, sem concatenação. Use-os para *interesse* e `generate_lead` para *demanda
-  realizada*; divergência entre os dois é problema de card, não de demanda.
+- **Sinal de interesse limpo:** filtre `whatsapp_click` por `service` exatamente igual ao
+  slug. O mesmo `guarda-corpo` sai do card da home, do card de bairro e da galeria; use
+  `context` (`service-card` ou `service-gallery`) apenas para quebrar por origem.
 - **Como ler:** compare o ranking com a ordem dos cards. Serviço no topo da demanda e no fim
   da página é troca de ordem, custo zero. Achado da própria estrutura: o formulário oferece
   **8** serviços e a página tem **6** cards — `Janelas de Alumínio` e `Tampos de Mesa` não
@@ -252,42 +254,37 @@ principais por sessão", que só existe depois de §3.
 | 6 | `form_interaction` | `form_action` = `submit_attempt` |
 | 7 | `generate_lead` | — |
 
-- **O bloco de serviços agora é mensurável direto.** Ele emite `field_focus` com
+- **O bloco opcional de serviços é mensurável direto.** Ele emite `field_focus` com
   `field_name = services`, então cabe uma etapa própria no funil, entre a 4 e a 5:
   `form_action` = `field_focus` e `field_name` = `services`. A queda dessa etapa para
   `service_selected` é literalmente "olhou as 8 opções e não marcou nenhuma" — antes esse
-  abandono não deixava rastro.
+  abandono não deixava rastro; não trate a queda como erro de validação.
 - **Confirmação independente:** tabela de formato livre com filtro `form_action` =
-  `validation_error`, linhas `field_name` e `error_message`. Se
-  `services` / `"Nenhum serviço selecionado"` for a maior linha, o bloco obrigatório é o
-  gargalo, e aí a decisão abaixo se sustenta em dois sinais e não em um.
+  `validation_error`, linhas `field_name` e `error_message`. `services` não deve aparecer:
+  o bloco é opcional.
 - **Armadilha de contagem:** `field_focus` dispara em **todo** focus (`app.js:789`). Em
   funil (por usuário) não distorce; em Contagem de eventos, distorce — nunca compare
   `field_focus` com `field_complete` por contagem.
 - **Como ler:** a maior queda percentual é o alvo, e só ela. Abaixo de ~30 inícios de
   formulário no período, leia só a **ordem** das etapas. Queda no `message` (opcional,
   último) não é problema.
-- **Decide:** trocar os checkboxes obrigatórios por um `<select>` de serviço principal, ou
-  tornar o bloco opcional. É a mudança de formulário com maior retorno esperado — e a única
-  que este funil consegue julgar.
+- **Decide:** simplificar, reordenar ou retirar opções quando o volume sustentar a leitura.
 
 ### 5.4 Qual CTA converte
 
-- **Pergunta:** quais dos ~11 links de WhatsApp da home merecem existir?
+- **Pergunta:** quais origens de CTA da home merecem existir?
 - **Tipo:** duas tabelas de formato livre, ambas com linhas `context` e colunas
   `page_type`. Na primeira, filtre Nome do evento = `whatsapp_impression`; na segunda,
   Nome do evento = `whatsapp_click`. Divida cliques por impressões fora do GA4.
 - **Por que a impressão é o denominador:** sticky só fica visível após 30% de rolagem,
   flutuante recua quando seria redundante/obstruiria conteúdo e CTAs de serviço só entram
   no viewport com scroll. Contagem bruta de clique mistura atratividade com exposição.
-- **Cardinalidade:** cada `context` emite no máximo uma impressão por pageview, mesmo se o
-  CTA sair e voltar ao viewport. Cliques continuam um por ação real e podem ser mais de um
-  no mesmo pageview.
-- **Valores de `context` que existem:** `floating-button` (`Base.astro:153`),
-  `sticky-cta` (`whatsapp-cta.js:253`), `footer-whatsapp` (`Footer.astro:62`),
-  `thank-you-page` (`obrigado.astro:32`), `service-*` (6 valores, `whatsapp-cta.js:318`),
-  `hero-whatsapp`, `cta-band`, `neighborhood-hero` e os handoffs
-  `form_fallback`/`form_error`.
+- **Cardinalidade:** cada combinação `context` + `service` emite no máximo uma impressão
+  por pageview, mesmo se o CTA sair e voltar ao viewport.
+- **Valores de `context`:** `floating-button`, `sticky-cta`, `footer-whatsapp`,
+  `thank-you-page`, `hero-whatsapp`, `cta-band`, `avaliar-link-invalido`,
+  `service-card`, `service-gallery` e os handoffs `form-fallback`/`form-error`.
+  Para comparar serviços, use a dimensão `service`, nunca extraia sufixo de `context`.
 - **Como ler:** zero clique com impressões confirmadas é candidato a remoção. Diferença
   entre CTAs vivos ainda precisa de ~30 cliques por CTA para valer discussão.
 - **Decide:** quais CTAs cortar. Onze links de WhatsApp numa página é muito, e todos
@@ -320,6 +317,10 @@ renomeado, mas comparar séries atravessando o deploy mistura definições difer
   evento por campo para exatamente um por formulário/pageview.
 - `lead_submit_attempt` e `whatsapp_impression` são novos. `lead_recovered` mantém o
   significado existente.
+- No deploy da taxonomia, `context` deixa de fundir origem e serviço. `service-*` e
+  `gallery-*` convergem em `service-card`/`service-gallery`; o novo parâmetro `service`
+  carrega o slug canônico. `form_fallback`/`form_error` viram
+  `form-fallback`/`form-error`. Use esse deploy como novo corte para relatórios por CTA.
 
 Registro de dimensão personalizada **não é retroativo** (§2), e correção de código também
 não reescreve evento histórico. Para qualquer taxa afetada, use o deploy como corte e não

--- a/docs/FOOTER_ENHANCEMENTS_DOCUMENTATION.md
+++ b/docs/FOOTER_ENHANCEMENTS_DOCUMENTATION.md
@@ -50,11 +50,13 @@ Aprimorar o footer com links de contato completos e implementar tracking avança
 #### ✅ **Novos Botões Adicionados:**
 - **Espelhos Sob Medida** 
   - Mensagem: "🪞 Olá! Gostaria de um orçamento para Espelhos Sob Medida."
-  - Context: `service-espelhos`
+  - Context: `service-card`
+  - Service: `espelho`
 
 - **Divisórias de Ambiente**
   - Mensagem: "🚪 Olá! Gostaria de um orçamento para Divisórias de Ambiente."
-  - Context: `service-divisórias`
+  - Context: `service-card`
+  - Service: `divisoria`
 
 **Agora TODOS os 6 cards de serviços têm botões de WhatsApp!**
 
@@ -337,9 +339,9 @@ Conversão
 - Segmentação: Desktop vs Mobile
 
 ✅ **Qual card de serviço tem mais cliques?**
-- Dimensão: `context`
-- Filtro: `event_name = 'whatsapp_click'`
-- Exemplos: `service-espelhos`, `service-divisórias`
+- Dimensão: `service`
+- Filtros: `event_name = 'whatsapp_click'` e `context = 'service-card'`
+- Exemplos: `espelho`, `divisoria`
 
 ---
 

--- a/docs/GA4_TRACKING_GUIDE.md
+++ b/docs/GA4_TRACKING_GUIDE.md
@@ -1,526 +1,160 @@
-# 📊 Guia Completo de Tracking GA4 - Verly Vidraçaria
+# Guia operacional de tracking GA4
 
-## 🎯 Visão Geral
+Este documento descreve o contrato atual da instrumentação da Verly. Para registrar
+dimensões, montar explorações e respeitar os cortes históricos, use também
+`ANALYTICS_PLAN.md`.
 
-Este documento descreve **todos os eventos do Google Analytics 4** implementados na landing page da Verly Vidraçaria para rastrear comportamento do usuário e otimizar conversões.
+- Medição GA4: `G-GDQV6C1NWH`
+- Implementação: `gtag` direto, sem GTM
+- Emissor comum: `trackGA4Event` em `public/js/app.js`
+- Contexto de página: `page_type` em todo evento e `neighborhood_page` nos bairros
+- PII: nome, telefone, e-mail, mensagem e hashes desses valores nunca vão ao GA4
 
-**Property ID:** `G-GDQV6C1NWH`  
-**Total de Eventos:** 15+ tipos de eventos  
-**Eventos Personalizados:** 10  
-**Eventos Padrão GA4:** 5  
+## Eventos
 
----
+| Evento | Quando sai | Parâmetros próprios principais |
+|---|---|---|
+| `page_view` | carregamento, pelo `gtag('config')` | automáticos + `page_type`, `neighborhood_page` quando aplicável |
+| `scroll_depth` | 25%, 50%, 75% e 100% | `percent_scrolled`, alturas |
+| `section_view` | 50% de qualquer `section[id]` visível | `section_id`, `section_name`, posição, tempo |
+| `cta_click` | `.btn-primary`, `.btn-success`, `.btn-secondary` | `button_text`, `button_location`, alvo |
+| `service_interaction` | clique em `.service-card` | nome exibido, posição, tipo |
+| `navigation_click` | menu, rodapé e navegação interna | texto, alvo, tipo |
+| `phone_click` | link `tel:` | número da loja, localização |
+| `contact_link_click` | e-mail ou endereço com `data-track` | `link_id`, tipo, texto |
+| `whatsapp_impression` | CTA de WhatsApp realmente visível | `context`, `service` opcional, `click_source`, texto |
+| `whatsapp_click` | clique real em link de WhatsApp | mesmos parâmetros da impressão |
+| `form_interaction` | foco, blur, validação e submit | `form_action`, `field_name`, comprimentos/erro quando existem |
+| `lead_submit_attempt` | payload válido antes da entrega | serviços canônicos, contagem e booleanos; sem PII |
+| `generate_lead` | API aceitou o lead (`2xx`) | mesmos dados da tentativa + resultado técnico |
+| `lead_recovered` | fila local foi aceita depois | motivo, tentativas e idade da fila |
+| `engagement_milestone` | 30, 60 e 120 segundos | marco e valor |
+| `review_*` | fluxo da página de avaliação | nota/contagens/erro conforme o desfecho |
 
-## 📈 Eventos Implementados
+`service_interaction` ainda seleciona também os cards de motivos dos bairros. Não use
+`service_name` para ranking até o seletor ser restringido em uma tarefa própria. Para
+interesse por serviço, use `whatsapp_click.service`.
 
-### 1. **page_view** (Padrão GA4)
+## WhatsApp: origem e serviço são dimensões separadas
 
-**Quando:** Página carrega  
-**Tipo:** Automático + Customizado  
+`context` responde **de onde veio o CTA**. `service` responde **qual serviço foi pedido**.
+Um valor nunca incorpora o outro.
 
-**Parâmetros:**
+Exemplos:
+
 ```javascript
 {
-  page_path: '/index.html',
-  page_referrer: 'https://google.com',
-  user_agent: 'Mozilla/5.0...',
-  screen_resolution: '1920x1080',
-  viewport_size: '1920x947',
-  device_type: 'desktop',
-  timestamp: '2025-10-08T...',
-  page_location: 'https://verlyvidracaria.com',
-  page_title: 'Vidraçaria Zona Oeste...'
+  context: 'service-card',
+  service: 'guarda-corpo',
+  click_source: 'inline_button'
 }
 ```
 
-**Objetivo:** Entender origem e dispositivo dos visitantes
-
----
-
-### 2. **scroll** (Padrão GA4)
-
-**Quando:** Usuário rola a página (25%, 50%, 75%, 100%)  
-**Tipo:** Customizado  
-
-**Parâmetros:**
 ```javascript
 {
-  percent_scrolled: 50,
-  scroll_depth_threshold: 50,
-  page_height: 4500,
-  viewport_height: 947,
-  timestamp: '...'
+  context: 'service-gallery',
+  service: 'guarda-corpo',
+  click_source: 'inline_button'
 }
 ```
 
-**Objetivo:** Medir engajamento e pontos de abandono
+As duas linhas somam em `service = guarda-corpo`; `context` permite comparar card e foto.
+CTAs genéricos não enviam `service`.
 
----
+Valores aceitos de `context`:
 
-### 3. **lead_submit_attempt** + **generate_lead**
+- `floating-button`
+- `footer-whatsapp`
+- `sticky-cta`
+- `hero-whatsapp`
+- `service-card`
+- `service-gallery`
+- `cta-band`
+- `thank-you-page`
+- `avaliar-link-invalido`
+- `form-fallback`
+- `form-error`
 
-**Quando:** `lead_submit_attempt` sai para cada payload válido prestes a ser enviado;
-`generate_lead` sai apenas quando a API confirma aceitação (`2xx`).
-**Tipo:** Tentativa + Conversão Principal confirmada
+Slugs canônicos de serviço:
 
-**Parâmetros:**
+- `box-banheiro`
+- `sacada`
+- `guarda-corpo`
+- `portas-janelas`
+- `espelho`
+- `divisoria`
+- `portao-aluminio`
+- `vidro-temperado`
+- `tampo-mesa`
+
+A fonte única desses slugs é `SERVICE_TAXONOMY` em `src/data/site.ts`. Card da home,
+card de bairro, galeria e formulário recebem a identidade a partir dela. Alterar copy não
+altera o slug.
+
+`whatsapp_impression` deduplica por combinação `context + service` por pageview. Isso
+evita que seis cards com `context = service-card` colapsem em uma única impressão.
+
+## Formulário
+
+Os campos obrigatórios são nome e telefone. E-mail, bairro, serviços e mensagem são
+opcionais.
+
+`services` em eventos de lead é uma lista deduplicada dos mesmos slugs canônicos usados
+por WhatsApp. Portas de vidro e janelas de alumínio pertencem à família
+`portas-janelas`; marcar as duas opções não repete o slug. O texto enviado à API e ao
+WhatsApp continua usando os rótulos visíveis.
+
+`generate_lead` só significa aceite `2xx`. Falha HTTP ou de rede pode exibir um link de
+handoff; `whatsapp_click` só sai se a pessoa clicar nesse link. Os contextos desses
+handoffs são `form-fallback` e `form-error`.
+
+## Depuração
+
+Para liberar logs locais:
+
+```text
+?analytics_debug=1
+```
+
+ou:
+
 ```javascript
-{
-  lead_source: 'contact_form',
-  services: 'Box para Banheiro, Sacada Envidraçada',
-  neighborhood: 'Barra da Tijuca',
-  api_status: 'success', // presente apenas em generate_lead
-  has_email: true,
-  has_message: true,
-  timestamp: '...'
-}
+localStorage.setItem('verly_debug', '1')
 ```
 
-**Objetivo:** Medir tentativa → aceite sem contar falha HTTP/rede como lead
+Isso apenas libera `console.log`; não ativa o DebugView. Para DebugView, conecte o domínio
+em `tagassistant.google.com`, abra **Administrador → Exibição de dados → DebugView** e
+confira o evento e seus parâmetros.
 
----
+No navegador, a prova bruta fica em **DevTools → Network**, filtro `collect`, requisição
+`g/collect`. Confira o nome do evento e os parâmetros, sem esperar que o console mostre
+eventos quando o modo local está desligado.
 
-### 4. **cta_click** (Customizado)
+## Guard de build
 
-**Quando:** Clique em qualquer botão CTA  
-**Tipo:** Interação  
+`npm run build` gera o site e depois abre todas as páginas HTML do `dist` em Chrome
+headless. A checagem usa o DOM final, portanto inclui sticky e botões de serviço criados
+em runtime.
 
-**Parâmetros:**
-```javascript
-{
-  button_text: 'Solicitar Orçamento Grátis',
-  button_location: 'hero', // 'hero', 'menu', 'floating', 'section', 'contact_form'
-  target_section: '#contato',
-  click_position_y: 250,
-  timestamp: '...'
-}
-```
+O build falha quando:
 
-**CTAs Rastreados:**
-- "Solicitar Orçamento Grátis" (hero)
-- "WhatsApp Direto" (hero)
-- "Orçamento Grátis" (menu)
-- "Solicitar Orçamento Grátis" (formulário)
-- Todos os botões .btn-primary, .btn-success, .btn-secondary
+- um link de WhatsApp não tem `data-context`;
+- `context` ou `service` contém acento, `_`, maiúscula ou separador inválido;
+- o valor não pertence ao registro gerado por `src/data/site.ts`;
+- `service-card` ou `service-gallery` não traz `data-service`.
 
-**Objetivo:** Identificar CTAs mais efetivos
+O guard descobre todas as páginas `*.html` recursivamente; não mantém uma lista de nomes.
+Em máquina sem Chrome no caminho padrão, defina `CHROME_PATH`.
 
----
+## Corte histórico
 
-### 5. **form_interaction** (Customizado)
+Não misture períodos anteriores e posteriores ao deploy desta taxonomia em uma mesma
+série por `context`:
 
-**Quando:** Qualquer interação com o formulário  
-**Tipo:** Interação + Conversão  
+- contextos `service-*` convergiram para `service-card`;
+- contextos `gallery-*` convergiram para `service-gallery`;
+- o serviço passou ao parâmetro `service`;
+- `form_fallback` e `form_error` viraram `form-fallback` e `form-error`.
 
-**Ações Rastreadas:**
-- `start` - Primeiro foco no formulário
-- `field_focus` - Campo recebe foco
-- `field_blur` - Campo perde foco
-- `field_complete` - Campo preenchido corretamente
-- `validation_error` - Erro de validação
-- `validation_failed` - Validação geral falhou
-- `submit_attempt` - Tentativa de envio
-- `submit_success` - Envio bem-sucedido
-- `submit_error` - Erro no envio
-
-**Parâmetros:**
-```javascript
-{
-  form_name: 'contact_form',
-  form_action: 'field_focus',
-  field_name: 'phone',
-  field_value_length: 15,
-  error_message: 'Telefone inválido',
-  timestamp: '...'
-}
-```
-
-**Objetivo:** Analisar funil de conversão do formulário e identificar pontos de fricção
-
----
-
-### 6. **whatsapp_click** (Customizado)
-
-**Quando:** Clique real em qualquer link do WhatsApp, inclusive o link de handoff exibido
-após falha do formulário. Renderizar o link não dispara o evento.
-**Tipo:** Interação + Conversão  
-
-**Parâmetros:**
-```javascript
-{
-  context: 'form_fallback',
-  click_source: 'inline_button',
-  button_text: 'Continuar no WhatsApp'
-}
-```
-
-**Locais Rastreados:**
-- Botão flutuante (canto inferior direito)
-- Hero CTA "WhatsApp Direto"
-- Link de handoff após erro da API
-
-O evento `whatsapp_impression` usa os mesmos parâmetros e dispara no máximo uma vez por
-`context` por pageview quando o CTA fica realmente visível. Ele é o denominador correto
-para comparar CTAs cuja exposição depende de scroll/visibilidade.
-
-**Objetivo:** Medir conversões via WhatsApp
-
----
-
-### 7. **phone_click** (Customizado)
-
-**Quando:** Clique em número de telefone  
-**Tipo:** Interação + Conversão  
-
-**Parâmetros:**
-```javascript
-{
-  phone_number: '+5521987926578',
-  click_location: 'contact_section', // 'header', 'contact_section', 'footer'
-  timestamp: '...'
-}
-```
-
-**Objetivo:** Rastrear conversões por telefone
-
----
-
-### 8. **navigation_click** (Customizado)
-
-**Quando:** Clique em menu, footer ou links internos  
-**Tipo:** Navegação  
-
-**Parâmetros:**
-```javascript
-{
-  link_text: 'Serviços',
-  link_target: '#servicos',
-  navigation_type: 'menu', // 'menu', 'footer', 'internal_link', 'mobile_menu_toggle'
-  timestamp: '...'
-}
-```
-
-**Objetivo:** Entender padrões de navegação
-
----
-
-### 9. **service_interaction** (Customizado)
-
-**Quando:** Clique em card de serviço  
-**Tipo:** Engajamento  
-
-**Parâmetros:**
-```javascript
-{
-  service_name: 'Box para Banheiro',
-  service_position: 1,
-  interaction_type: 'click',
-  timestamp: '...'
-}
-```
-
-**Serviços Rastreados:**
-1. Box para Banheiro
-2. Sacadas Envidraçadas
-3. Guarda-corpos de Vidro
-4. Portas e Janelas
-5. Espelhos Sob Medida
-6. Divisórias de Ambiente
-
-**Objetivo:** Identificar serviços mais interessantes
-
----
-
-### 10. **section_view** (Customizado)
-
-**Quando:** Seção entra no viewport (50% visível)  
-**Tipo:** Engajamento  
-
-**Parâmetros:**
-```javascript
-{
-  section_name: 'Nossos Serviços',
-  section_id: 'servicos',
-  scroll_position: 850,
-  time_on_page: 25, // segundos
-  timestamp: '...'
-}
-```
-
-**Seções Rastreadas:**
-- Hero (topo)
-- Serviços (#servicos)
-- Diferenciais (#diferenciais)
-- Depoimentos (#depoimentos)
-- Formulário (#contato)
-
-**Objetivo:** Medir engajamento com cada seção
-
----
-
-### 11. **engagement_milestone** (Customizado)
-
-**Quando:** Marcos de tempo na página  
-**Tipo:** Engajamento  
-
-**Parâmetros:**
-```javascript
-{
-  milestone_name: 'time_30s',
-  milestone_value: 30,
-  timestamp: '...'
-}
-```
-
-**Milestones Rastreados:**
-- 30 segundos
-- 60 segundos (1 minuto)
-- 120 segundos (2 minutos)
-
-**Objetivo:** Medir qualidade de tráfego e engajamento
-
----
-
-## 🎯 Eventos por Categoria
-
-### **Conversão (Alta Prioridade)**
-1. ✅ `generate_lead` - Lead gerado
-2. ✅ `form_interaction` (submit_success)
-3. ✅ `whatsapp_click`
-4. ✅ `phone_click`
-5. ✅ `cta_click`
-
-### **Engajamento**
-1. ✅ `scroll` - Profundidade de scroll
-2. ✅ `section_view` - Visualização de seções
-3. ✅ `engagement_milestone` - Tempo na página
-4. ✅ `service_interaction` - Interesse em serviços
-
-### **Navegação**
-1. ✅ `navigation_click` - Cliques em menu/links
-2. ✅ `page_view` - Visualizações de página
-
-### **Formulário (Funil)**
-1. ✅ `form_interaction` (start)
-2. ✅ `form_interaction` (field_focus)
-3. ✅ `form_interaction` (field_complete)
-4. ✅ `form_interaction` (validation_error)
-5. ✅ `form_interaction` (submit_attempt)
-6. ✅ `form_interaction` (submit_success)
-
----
-
-## 📊 Relatórios Recomendados no GA4
-
-### 1. **Funil de Conversão do Formulário**
-
-```
-Etapa 1: form_interaction (start)
-Etapa 2: form_interaction (field_complete) onde field_name = 'name'
-Etapa 3: form_interaction (field_complete) onde field_name = 'phone'
-Etapa 4: form_interaction (field_complete) onde field_name = 'neighborhood'
-Etapa 5: form_interaction (submit_attempt)
-Etapa 6: generate_lead
-```
-
-**Objetivo:** Identificar onde usuários abandonam o formulário
-
----
-
-### 2. **Análise de CTAs**
-
-**Métricas:**
-- Cliques por CTA (button_text)
-- Taxa de conversão por localização (button_location)
-- CTAs que mais geram leads
-
-**Segmentação:**
-- Por dispositivo (device_type)
-- Por fonte de tráfego (page_referrer)
-
----
-
-### 3. **Análise de Scroll Depth**
-
-**Métricas:**
-- % de usuários que chegam a 25%, 50%, 75%, 100%
-- Correlação entre scroll e conversão
-- Identificar ponto de abandono
-
----
-
-### 4. **Análise de Serviços**
-
-**Métricas:**
-- Serviços mais clicados (service_name)
-- Serviços mais selecionados no formulário
-- Taxa de conversão por serviço
-
----
-
-### 5. **Tempo de Engajamento**
-
-**Métricas:**
-- % de usuários que ficam 30s, 60s, 120s
-- Tempo médio por seção
-- Correlação entre tempo e conversão
-
----
-
-### 6. **Análise de Erros de Validação**
-
-**Métricas:**
-- Campos com mais erros (field_name)
-- Tipos de erro mais comuns (error_message)
-- Taxa de abandono após erro
-
----
-
-## 🔍 Como Usar no GA4
-
-### Ver Eventos em Tempo Real:
-
-1. Acesse GA4: https://analytics.google.com
-2. Vá em **Relatórios** → **Tempo real**
-3. Veja eventos acontecendo ao vivo
-
-### Criar Relatório Personalizado:
-
-1. Vá em **Explorar** → **Análise de exploração**
-2. Adicione dimensões:
-   - Nome do evento
-   - button_text (para CTAs)
-   - field_name (para formulário)
-   - service_name (para serviços)
-3. Adicione métricas:
-   - Total de eventos
-   - Eventos por usuário
-   - Taxa de conversão
-
-### Criar Conversão:
-
-1. Vá em **Configurar** → **Eventos**
-2. Marque `generate_lead` como **Conversão**
-3. Marque `whatsapp_click` como **Conversão** (opcional)
-4. Marque `phone_click` como **Conversão** (opcional)
-
----
-
-## 🎯 KPIs Principais para Monitorar
-
-### Conversão:
-- ✅ **Taxa de conversão geral** (generate_lead / page_view)
-- ✅ **Taxa de conclusão do formulário** (submit_success / submit_attempt)
-- ✅ **Taxa de WhatsApp** (whatsapp_click / page_view)
-
-### Engajamento:
-- ✅ **Scroll depth médio**
-- ✅ **Tempo médio na página**
-- ✅ **Seções mais visualizadas**
-- ✅ **Serviços mais populares**
-
-### Fricção:
-- ✅ **Taxa de erro de validação**
-- ✅ **Campos mais problemáticos**
-- ✅ **Taxa de abandono do formulário**
-
-### CTAs:
-- ✅ **CTA mais clicado**
-- ✅ **Melhor localização de CTA**
-- ✅ **Taxa de conversão por CTA**
-
----
-
-## 🧪 Como Testar
-
-### Teste 1: Verificar Console
-
-1. Abra o site: https://verlyvidracaria.com
-2. Abra DevTools (F12)
-3. Vá na aba Console
-4. Você deve ver: `📊 GA4 Event: ...` a cada interação
-
-### Teste 2: Verificar Network
-
-1. Abra DevTools → Network
-2. Filtre por "collect" ou "analytics"
-3. Interaja com o site
-4. Veja requisições para `google-analytics.com/g/collect`
-
-### Teste 3: Tempo Real no GA4
-
-1. Abra GA4 em outra aba
-2. Vá em Tempo Real
-3. Navegue pelo site
-4. Veja eventos aparecendo instantaneamente
-
----
-
-## 📋 Checklist de Validação
-
-- [ ] GA4 property ID correto: `G-GDQV6C1NWH`
-- [ ] Eventos aparecem no console
-- [ ] Eventos aparecem no GA4 Tempo Real
-- [ ] `generate_lead` marcado como conversão
-- [ ] Parâmetros personalizados sendo enviados
-- [ ] Eventos de formulário funcionando
-- [ ] Eventos de CTA funcionando
-- [ ] Eventos de scroll funcionando
-- [ ] Eventos de seção funcionando
-- [ ] Eventos de WhatsApp funcionando
-
----
-
-## 🚀 Benefícios Desta Implementação
-
-### Para Marketing:
-- ✅ Entender quais fontes geram leads qualificados
-- ✅ Otimizar campanhas baseado em dados reais
-- ✅ ROI preciso de cada canal
-
-### Para Produto:
-- ✅ Identificar pontos de fricção no formulário
-- ✅ Saber quais serviços geram mais interesse
-- ✅ Melhorar UX baseado em comportamento real
-
-### Para Vendas:
-- ✅ Qualificar leads antes de contato
-- ✅ Saber qual serviço o cliente procura
-- ✅ Priorizar leads mais engajados
-
-### Para Negócio:
-- ✅ Decisões baseadas em dados
-- ✅ Aumento de conversão
-- ✅ Redução de custo por lead
-
----
-
-## 📞 Suporte
-
-**Dúvidas sobre eventos?**
-- Consulte este documento
-- Veja comentários no código (`js/app.js`)
-- Use GA4 Debug Mode
-
-**Quer adicionar novos eventos?**
-- Use a função `trackGA4Event(eventName, params)`
-- Siga o padrão snake_case para nomes
-- Adicione parâmetros relevantes
-
----
-
-## ✅ Resumo
-
-**15+ tipos de eventos implementados**  
-**100+ pontos de tracking na página**  
-**Cobertura completa do funil de conversão**  
-**Dados acionáveis para otimização**  
-
-**O tracking GA4 mais completo para uma landing page de vidraçaria! 🎯**
-
----
-
-**Última atualização:** 08/10/2025  
-**Versão:** 2.0 (GA4 completo)  
-**Desenvolvido por:** Cursor AI + Claude Sonnet 4.5
-
+O registro de dimensão personalizada não é retroativo. Registre `context` e `service`
+antes de iniciar o novo baseline.

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "build": "npm run check:contrast && astro build",
+    "build": "npm run check:contrast && astro build && npm run check:analytics",
     "preview": "astro preview",
-    "check:contrast": "node scripts/check-contrast.mjs"
+    "check:contrast": "node scripts/check-contrast.mjs",
+    "check:analytics": "node scripts/check-whatsapp-taxonomy.mjs"
   },
   "dependencies": {
     "astro": "^5.18.2"

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -487,54 +487,9 @@ function validateField(field) {
  * conseguia enviar sem responder.
  */
 
-// ============================================================================
-// SERVIÇOS — CHAVE CURTA E ESTÁVEL
-// ============================================================================
-
-/**
- * Slug por serviço.
- *
- * O rótulo do checkbox é bom para ler e ruim para medir: a lista dos 8 concatenada dá
- * 127 caracteres e o GA4 corta valor de parâmetro em 100 — a seleção grande, que é
- * justamente o lead mais valioso, chegava truncada e virava linha espúria no relatório.
- * Os 8 slugs concatenados dão 85 caracteres, então nenhuma seleção possível é cortada.
- *
- * O mapa é explícito (e não só derivado do rótulo) porque a chave precisa sobreviver a
- * mudança de copy: trocar "Box para Banheiro" por "Box de Banheiro" não pode virar um
- * serviço novo no relatório.
- *
- * NENHUM slug é pedaço de outro. Isso é requisito, não coincidência: a leitura por
- * serviço é um filtro "services contém <slug>", e um slug contido em outro faria uma
- * linha contar leads da outra. Serviço novo aqui precisa manter essa propriedade.
- *
- * Um evento por serviço foi tentado e descartado: medindo o envio real, um lead com os
- * 8 serviços emite 8 eventos a mais no mesmo instante, o gtag os agrupa num lote só, e
- * o lote perde eventos — 3 dos 8 se perderam no caminho de sucesso, que redireciona
- * para /obrigado.html 1,2 s depois. Contagem por serviço que perde evento é pior que
- * filtro "contém", porque o erro não aparece em lugar nenhum.
- */
-const SERVICE_SLUGS = {
-    'Box para Banheiro': 'box',
-    'Sacada Envidraçada': 'sacada',
-    'Guarda-corpo': 'guarda_corpo',
-    'Portas de Vidro': 'portas_vidro',
-    'Janelas de Alumínio': 'janelas_aluminio',
-    'Espelhos': 'espelhos',
-    'Divisórias': 'divisorias',
-    'Tampos de Mesa': 'tampos_mesa'
-};
-
-function serviceSlug(value) {
-    if (SERVICE_SLUGS[value]) return SERVICE_SLUGS[value];
-    // Serviço novo no markup sem passar por aqui: melhor um slug derivado do que
-    // perder a linha no relatório.
-    return String(value)
-        .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '_')
-        .replace(/^_+|_+$/g, '');
-}
+// O rótulo dos checkboxes continua apropriado para a API e o WhatsApp. A identidade
+// estável do analytics vem separada em data-service, gerada pela taxonomia única de
+// src/data/site.ts; este script não mantém uma segunda tabela de equivalência.
 
 // ============================================================================
 // ENTREGA DO LEAD — KEEPALIVE, TENTATIVAS E FILA LOCAL
@@ -826,7 +781,11 @@ async function handleFormSubmit(event) {
     // Get selected services
     const selectedServices = Array.from(document.querySelectorAll('input[name="services"]:checked'))
         .map(cb => cb.value);
-    const selectedServiceSlugs = selectedServices.map(serviceSlug);
+    const selectedServiceSlugs = [...new Set(
+        Array.from(document.querySelectorAll('input[name="services"]:checked'))
+            .map(cb => cb.dataset.service)
+            .filter(Boolean)
+    )];
 
     // O que o WhatsApp precisa, capturado ANTES do reset do formulário: `reset()` zera
     // os campos, e a mensagem de fallback era montada depois dele com
@@ -966,7 +925,7 @@ async function handleFormSubmit(event) {
             const encodedMessage = encodeURIComponent(whatsappMessage);
             const whatsappURL = `https://wa.me/5521987926578?text=${encodedMessage}`;
 
-            const handoffContext = result.status === 'fetch_error' ? 'form_error' : 'form_fallback';
+            const handoffContext = result.status === 'fetch_error' ? 'form-error' : 'form-fallback';
             showWhatsAppHandoff(
                 queued
                     ? 'Sem conexão para enviar agora. Seu pedido ficou salvo e será reenviado quando a internet voltar.'

--- a/public/js/whatsapp-cta.js
+++ b/public/js/whatsapp-cta.js
@@ -67,19 +67,6 @@ const WhatsAppCTA = {
     messages: {
         hero: '🏠 Olá! Gostaria de solicitar um orçamento para vidraçaria.',
         services: '✨ Olá! Vi os serviços no site e gostaria de saber mais sobre:',
-        boxBanheiro: '🚿 Olá! Gostaria de um orçamento para Box para Banheiro.',
-        sacada: '🏢 Olá! Gostaria de um orçamento para Sacadas Envidraçadas.',
-        guardaCorpo: '🛡️ Olá! Gostaria de um orçamento para Guarda-corpos de Vidro.',
-        portas: '🚪 Olá! Gostaria de um orçamento para Portas e Janelas.',
-        janelas: '🪟 Olá! Gostaria de um orçamento para Janelas de Alumínio.',
-        espelhos: '🪞 Olá! Gostaria de um orçamento para Espelhos Sob Medida.',
-        divisorias: '🚪 Olá! Gostaria de um orçamento para Divisórias de Ambiente.',
-        cortinasVidro: '🏢 Olá! Gostaria de um orçamento para Instalação de cortinas de vidro.',
-        boxBlindex: '🚿 Olá! Gostaria de um orçamento para Box blindex para banheiro.',
-        portasVidroTemperado: '🚪 Olá! Gostaria de um orçamento para Portas de vidro temperado.',
-        guardaCorpoVidro: '🛡️ Olá! Gostaria de um orçamento para Guarda corpo em vidro.',
-        portoesAluminio: '🚪 Olá! Gostaria de um orçamento para Portões em alumínio.',
-        vidrosTemperados: '✨ Olá! Gostaria de um orçamento para Vidros temperados sob medida.',
         contact: '📋 Olá! Vim pelo formulário de contato e gostaria de mais informações.',
         floating: '💬 Olá! Gostaria de solicitar um orçamento.',
         sticky: '💬 Olá! Fiquei com uma dúvida e gostaria de conversar.',
@@ -315,21 +302,6 @@ const WhatsAppCTA = {
      * Incluindo Espelhos e Divisórias
      */
     addServiceCTAs() {
-        const services = {
-            'box-banheiro': { message: this.messages.boxBanheiro, context: 'service-box-banheiro' },
-            'sacada-envidracada': { message: this.messages.sacada, context: 'service-sacada' },
-            'guarda-corpos-vidro': { message: this.messages.guardaCorpo, context: 'service-guarda-corpo' },
-            'portas-janelas': { message: this.messages.portas, context: 'service-portas' },
-            'espelhos-sob-medida': { message: this.messages.espelhos, context: 'service-espelhos' },
-            'divisorias-ambiente': { message: this.messages.divisorias, context: 'service-divisórias' },
-            'cortinas-vidro': { message: this.messages.cortinasVidro, context: 'service-cortinas-vidro' },
-            'box-blindex-banheiro': { message: this.messages.boxBlindex, context: 'service-box-blindex-banheiro' },
-            'portas-vidro-temperado': { message: this.messages.portasVidroTemperado, context: 'service-portas-vidro-temperado' },
-            'guarda-corpo-vidro': { message: this.messages.guardaCorpoVidro, context: 'service-guarda-corpo-vidro' },
-            'portoes-aluminio': { message: this.messages.portoesAluminio, context: 'service-portoes-aluminio' },
-            'vidros-temperados-sob-medida': { message: this.messages.vidrosTemperados, context: 'service-vidros-temperados-sob-medida' }
-        };
-
         let addedCount = 0;
 
         document.querySelectorAll('#servicos .service-card').forEach(card => {
@@ -339,11 +311,10 @@ const WhatsAppCTA = {
             }
 
             const heading = card.querySelector('h3')?.textContent.trim() || '';
-            const serviceKey = card.dataset.service || '';
-            const service = services[serviceKey];
-            // Um serviço novo nunca deve herdar a mensagem de outro: o título visível
-            // é a fonte mais segura, e a mensagem genérica fica só para card sem título.
-            const message = service?.message || (heading
+            const service = card.dataset.service || '';
+            // Slug e mensagem vêm do markup gerado pela taxonomia de site.ts. O título
+            // visível é a rede de segurança para um card sem mensagem.
+            const message = card.dataset.whatsappMessage || (heading
                 ? `✨ Olá! Gostaria de um orçamento para ${heading}.`
                 : this.messages.services);
 
@@ -355,7 +326,8 @@ const WhatsAppCTA = {
                 ${this.iconHTML()}
                 <span>Pedir Orçamento</span>
             `;
-            ctaButton.dataset.context = service?.context || `service-${serviceKey || 'unknown'}`;
+            ctaButton.dataset.context = 'service-card';
+            if (service) ctaButton.dataset.service = service;
             ctaButton.setAttribute('target', '_blank');
             ctaButton.setAttribute('rel', 'noopener noreferrer');
 
@@ -422,10 +394,9 @@ const WhatsAppCTA = {
          * dobra o volume e joga metade de qualquer tabela por origem em "(não definido)".
          *
          * Ficou o delegado, e não o por elemento, porque ele alcança os CTAs criados em
-         * runtime (a sticky e os 6 dos cards de serviço) e lê o `data-context` que o
-         * markup já traz. Os DOIS parâmetros continuam saindo: `context` é a origem
-         * nomeada na página, `click_source` é a categoria que o ouvinte do app.js
-         * calculava — nada se perde na consolidação.
+         * runtime (a sticky e os cards de serviço) e lê os atributos do markup.
+         * `context` responde de onde veio o CTA; `service`, quando existe, identifica
+         * o serviço sem incorporar a origem ao slug.
          */
         document.addEventListener('click', (e) => {
             const target = e.target.closest(whatsappSelector);
@@ -441,15 +412,16 @@ const WhatsAppCTA = {
                 ctaTrack('whatsapp_click', {
                     context: context,
                     click_source: clickSource,
-                    button_text: target.textContent.trim()
+                    button_text: target.textContent.trim(),
+                    ...(target.dataset.service ? { service: target.dataset.service } : {})
                 });
 
-                ctaLog(`📊 WhatsApp click tracked: ${context} (${clickSource})`);
+                ctaLog(`📊 WhatsApp click tracked: ${context} (${target.dataset.service || 'sem serviço'}, ${clickSource})`);
             }
         });
 
         /**
-         * Denominador dos cliques: uma impressão por contexto por pageview.
+         * Denominador dos cliques: uma impressão por origem + serviço por pageview.
          *
          * IntersectionObserver mantém o custo fora do scroll handler. A checagem de
          * estilo evita contar a sticky enquanto está recolhida e o flutuante enquanto
@@ -458,7 +430,7 @@ const WhatsAppCTA = {
          * formulário, que é criado depois do carregamento.
          */
         if ('IntersectionObserver' in window) {
-            const impressedContexts = new Set();
+            const impressedCtas = new Set();
             const intersectingLinks = new WeakSet();
             const observedLinks = new WeakSet();
 
@@ -482,15 +454,18 @@ const WhatsAppCTA = {
                 if (!intersectingLinks.has(target) || !isRendered(target)) return;
 
                 const context = target.dataset.context || 'unknown';
-                if (impressedContexts.has(context)) return;
-                impressedContexts.add(context);
+                const service = target.dataset.service || '';
+                const ctaIdentity = `${context}:${service}`;
+                if (impressedCtas.has(ctaIdentity)) return;
+                impressedCtas.add(ctaIdentity);
 
                 ctaTrack('whatsapp_impression', {
                     context,
                     click_source: clickSourceFor(target),
-                    button_text: target.textContent.trim()
+                    button_text: target.textContent.trim(),
+                    ...(service ? { service } : {})
                 });
-                ctaLog(`📊 WhatsApp impression tracked: ${context}`);
+                ctaLog(`📊 WhatsApp impression tracked: ${context} (${service || 'sem serviço'})`);
             };
 
             const impressionObserver = new IntersectionObserver((entries) => {

--- a/scripts/check-whatsapp-taxonomy.mjs
+++ b/scripts/check-whatsapp-taxonomy.mjs
@@ -1,0 +1,166 @@
+import { accessSync, constants, existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { basename, extname, join, relative, resolve, sep } from 'node:path';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('../', import.meta.url));
+const DIST = join(ROOT, 'dist');
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SERVICE_CONTEXTS = new Set(['service-card', 'service-gallery']);
+
+const walkHtml = (directory) =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return walkHtml(path);
+    return entry.isFile() && entry.name.endsWith('.html') ? [path] : [];
+  });
+
+const executable = (path) => {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const chromeCandidates = [
+  process.env.CHROME_PATH,
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/usr/bin/google-chrome',
+  '/usr/bin/google-chrome-stable',
+  '/usr/bin/chromium',
+  '/usr/bin/chromium-browser',
+].filter(Boolean);
+
+for (const directory of (process.env.PATH || '').split(sep)) {
+  chromeCandidates.push(join(directory, 'google-chrome'));
+  chromeCandidates.push(join(directory, 'google-chrome-stable'));
+  chromeCandidates.push(join(directory, 'chromium'));
+}
+
+const chrome = chromeCandidates.find((candidate) => existsSync(candidate) && executable(candidate));
+if (!chrome) {
+  console.error('✗ Chrome/Chromium não encontrado; defina CHROME_PATH para validar o DOM final.');
+  process.exit(1);
+}
+
+const contentType = (path) => ({
+  '.css': 'text/css',
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+}[extname(path)] || 'application/octet-stream');
+
+const server = createServer((request, response) => {
+  const pathname = decodeURIComponent(new URL(request.url, 'http://127.0.0.1').pathname);
+  const requested = resolve(DIST, `.${pathname}`);
+  if (requested !== DIST && !requested.startsWith(`${DIST}${sep}`)) {
+    response.writeHead(403).end('Forbidden');
+    return;
+  }
+
+  try {
+    const body = readFileSync(requested);
+    response.writeHead(200, { 'content-type': contentType(requested) }).end(body);
+  } catch {
+    response.writeHead(404).end('Not found');
+  }
+});
+
+await new Promise((resolveListening) => server.listen(0, '127.0.0.1', resolveListening));
+const { port } = server.address();
+
+const dumpDom = (page) => new Promise((resolveDump, rejectDump) => {
+  const profile = mkdtempSync(join(tmpdir(), 'verly-analytics-'));
+  execFile(chrome, [
+    '--headless',
+    '--disable-gpu',
+    '--disable-dev-shm-usage',
+    '--no-sandbox',
+    '--disable-background-networking',
+    '--dump-dom',
+    '--virtual-time-budget=1000',
+    `--user-data-dir=${profile}`,
+    `http://127.0.0.1:${port}/${relative(DIST, page)}`,
+  ], { encoding: 'utf8', maxBuffer: 20 * 1024 * 1024, timeout: 30_000 }, (error, stdout) => {
+    rmSync(profile, { recursive: true, force: true });
+    if (error) rejectDump(error);
+    else resolveDump(stdout);
+  });
+});
+
+const attr = (tag, name) => tag.match(new RegExp(`\\b${name}="([^"]*)"`, 'i'))?.[1];
+const pages = walkHtml(DIST).sort();
+const failures = [];
+let checkedLinks = 0;
+
+try {
+  // Quatro navegadores reduzem o tempo sem pressionar demais o runner do CI.
+  for (let offset = 0; offset < pages.length; offset += 4) {
+    const batch = pages.slice(offset, offset + 4);
+    const doms = await Promise.all(batch.map(dumpDom));
+
+    batch.forEach((page, index) => {
+      const html = doms[index];
+      const pageName = relative(DIST, page);
+      const body = html.match(/<body\b[^>]*>/i)?.[0] || '';
+      const contexts = new Set((attr(body, 'data-whatsapp-contexts') || '').split(',').filter(Boolean));
+      const services = new Set((attr(body, 'data-service-slugs') || '').split(',').filter(Boolean));
+
+      if (!contexts.size || !services.size) {
+        failures.push(`${pageName}: registro de contextos/serviços ausente no <body>`);
+        return;
+      }
+
+      const links = [...html.matchAll(/<a\b[^>]*>/gi)]
+        .map(([tag]) => tag)
+        .filter((tag) => /(?:wa\.me|whatsapp)/i.test(attr(tag, 'href') || ''));
+      checkedLinks += links.length;
+
+      links.forEach((tag, linkIndex) => {
+        const location = `${pageName} link WhatsApp #${linkIndex + 1}`;
+        const context = attr(tag, 'data-context');
+        const service = attr(tag, 'data-service');
+
+        if (!context) {
+          failures.push(`${location}: data-context ausente`);
+        } else if (!SLUG.test(context)) {
+          failures.push(`${location}: context "${context}" fora da convenção [a-z0-9-]`);
+        } else if (!contexts.has(context)) {
+          failures.push(`${location}: context desconhecido "${context}"`);
+        }
+
+        if (service !== undefined) {
+          if (!SLUG.test(service)) {
+            failures.push(`${location}: service "${service}" fora da convenção [a-z0-9-]`);
+          } else if (!services.has(service)) {
+            failures.push(`${location}: service desconhecido "${service}"`);
+          }
+        }
+
+        if (SERVICE_CONTEXTS.has(context) && !service) {
+          failures.push(`${location}: context "${context}" exige data-service`);
+        }
+      });
+    });
+  }
+} catch (error) {
+  failures.push(`Chrome não conseguiu renderizar o dist: ${error.message}`);
+} finally {
+  await new Promise((resolveClose) => server.close(resolveClose));
+}
+
+if (failures.length) {
+  console.error('✗ Taxonomia de WhatsApp inválida no DOM final:');
+  failures.forEach((failure) => console.error(`  ${failure}`));
+  process.exit(1);
+}
+
+console.log(`✓ Taxonomia de WhatsApp: ${checkedLinks} links em ${pages.length} páginas renderizadas`);

--- a/src/components/QuoteForm.astro
+++ b/src/components/QuoteForm.astro
@@ -1,6 +1,6 @@
 ---
 import Icon from '../components/Icon.astro';
-import { CONTACT, NEIGHBORHOOD_OPTIONS } from '../data/site';
+import { CONTACT, NEIGHBORHOOD_OPTIONS, SERVICE_TAXONOMY } from '../data/site';
 
 interface Props {
   /** Bairro da página — pré-seleciona a opção no <select>. A escolha segue editável:
@@ -171,35 +171,35 @@ const {
                                     <div class="form-label" id="services-label">Serviços de interesse</div>
                                     <div class="checkbox-group">
                                         <div class="checkbox-item">
-                                            <input type="checkbox" id="service1" name="services" value="Box para Banheiro">
+                                            <input type="checkbox" id="service1" name="services" value="Box para Banheiro" data-service={SERVICE_TAXONOMY.boxBanheiro.slug}>
                                             <label for="service1">Box para Banheiro</label>
                                         </div>
                                         <div class="checkbox-item">
-                                            <input type="checkbox" id="service2" name="services" value="Sacada Envidraçada">
+                                            <input type="checkbox" id="service2" name="services" value="Sacada Envidraçada" data-service={SERVICE_TAXONOMY.sacadaEnvidracada.slug}>
                                             <label for="service2">Sacada Envidraçada</label>
                                         </div>
                                         <div class="checkbox-item">
-                                            <input type="checkbox" id="service3" name="services" value="Guarda-corpo">
+                                            <input type="checkbox" id="service3" name="services" value="Guarda-corpo" data-service={SERVICE_TAXONOMY.guardaCorpo.slug}>
                                             <label for="service3">Guarda-corpo</label>
                                         </div>
                                         <div class="checkbox-item">
-                                            <input type="checkbox" id="service4" name="services" value="Portas de Vidro">
+                                            <input type="checkbox" id="service4" name="services" value="Portas de Vidro" data-service={SERVICE_TAXONOMY.portasJanelas.slug}>
                                             <label for="service4">Portas de Vidro</label>
                                         </div>
                                         <div class="checkbox-item">
-                                            <input type="checkbox" id="service5" name="services" value="Janelas de Alumínio">
+                                            <input type="checkbox" id="service5" name="services" value="Janelas de Alumínio" data-service={SERVICE_TAXONOMY.portasJanelas.slug}>
                                             <label for="service5">Janelas de Alumínio</label>
                                         </div>
                                         <div class="checkbox-item">
-                                            <input type="checkbox" id="service6" name="services" value="Espelhos">
+                                            <input type="checkbox" id="service6" name="services" value="Espelhos" data-service={SERVICE_TAXONOMY.espelhoSobMedida.slug}>
                                             <label for="service6">Espelhos</label>
                                         </div>
                                         <div class="checkbox-item">
-                                            <input type="checkbox" id="service7" name="services" value="Divisórias">
+                                            <input type="checkbox" id="service7" name="services" value="Divisórias" data-service={SERVICE_TAXONOMY.divisoriaAmbiente.slug}>
                                             <label for="service7">Divisórias</label>
                                         </div>
                                         <div class="checkbox-item">
-                                            <input type="checkbox" id="service8" name="services" value="Tampos de Mesa">
+                                            <input type="checkbox" id="service8" name="services" value="Tampos de Mesa" data-service={SERVICE_TAXONOMY.tampoMesa.slug}>
                                             <label for="service8">Tampos de Mesa</label>
                                         </div>
                                     </div>

--- a/src/components/ServiceGallery.astro
+++ b/src/components/ServiceGallery.astro
@@ -1,5 +1,5 @@
 ---
-import { CONTACT } from '../data/site';
+import { CONTACT, SERVICE_TAXONOMY } from '../data/site';
 
 /**
  * Galeria de serviços.
@@ -19,35 +19,35 @@ import { CONTACT } from '../data/site';
  */
 const panes = [
   {
-    service: 'box-banheiro',
+    service: SERVICE_TAXONOMY.boxBanheiro,
     label: 'Box para banheiro',
     detail: 'Temperado 8mm, ferragem preta',
     img: '/img/servicos/box-banheiro.webp',
     alt: 'Box de banheiro em vidro temperado com perfil e puxador pretos, instalado em nicho revestido.',
   },
   {
-    service: 'sacada-envidracada',
+    service: SERVICE_TAXONOMY.sacadaEnvidracada,
     label: 'Sacada envidraçada',
     detail: 'Cortina de vidro retrátil',
     img: '/img/servicos/sacada-envidracada.webp',
     alt: 'Varanda envidraçada com folhas de vidro recolhidas na lateral e guarda-corpo de vidro.',
   },
   {
-    service: 'guarda-corpos-vidro',
+    service: SERVICE_TAXONOMY.guardaCorpo,
     label: 'Guarda-corpo',
     detail: 'Vidro com corrimão de inox',
     img: '/img/servicos/guarda-corpos-vidro.webp',
     alt: 'Guarda-corpo de vidro com corrimão de aço inox e prendedores redondos, em varanda externa.',
   },
   {
-    service: 'portas-janelas',
+    service: SERVICE_TAXONOMY.portasJanelas,
     label: 'Portas e janelas',
     detail: 'Perfil de alumínio sob medida',
     img: '/img/servicos/portas-janelas.webp',
     alt: 'Divisória envidraçada de piso a teto com perfil escuro separando dois ambientes de uma sala.',
   },
   {
-    service: 'espelhos-sob-medida',
+    service: SERVICE_TAXONOMY.espelhoSobMedida,
     label: 'Espelho sob medida',
     detail: 'Corte e instalação no local',
     img: '/img/servicos/espelhos-sob-medida.webp',
@@ -78,8 +78,8 @@ const waLink = (label: string) =>
           href={waLink(p.label)}
           target="_blank"
           rel="noopener noreferrer"
-          data-service={p.service}
-          data-context={`gallery-${p.service}`}
+          data-service={p.service.slug}
+          data-context="service-gallery"
         >
           <img src={p.img} alt={p.alt} width="800" height="600" loading="lazy" decoding="async" />
           <span class="pane-caption">

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -111,6 +111,70 @@ export const GOOGLE_REVIEWS = {
   ],
 };
 
+/**
+ * Taxonomia canônica de serviços usada por cards, galeria, formulário e analytics.
+ *
+ * `slug` é identidade de relatório, não copy. Uma origem diferente (card/foto/página
+ * local) continua apontando para o mesmo slug; a origem vai separada em `context`.
+ * Manter os slugs aqui evita que cada emissor invente grafia, plural ou qualificador.
+ */
+export const SERVICE_TAXONOMY = {
+  boxBanheiro: {
+    slug: 'box-banheiro',
+    whatsappMessage: '🚿 Olá! Gostaria de um orçamento para Box para Banheiro.',
+  },
+  sacadaEnvidracada: {
+    slug: 'sacada',
+    whatsappMessage: '🏢 Olá! Gostaria de um orçamento para Sacadas Envidraçadas.',
+  },
+  guardaCorpo: {
+    slug: 'guarda-corpo',
+    whatsappMessage: '🛡️ Olá! Gostaria de um orçamento para Guarda-corpos de Vidro.',
+  },
+  portasJanelas: {
+    slug: 'portas-janelas',
+    whatsappMessage: '🚪 Olá! Gostaria de um orçamento para Portas e Janelas.',
+  },
+  espelhoSobMedida: {
+    slug: 'espelho',
+    whatsappMessage: '🪞 Olá! Gostaria de um orçamento para Espelhos Sob Medida.',
+  },
+  divisoriaAmbiente: {
+    slug: 'divisoria',
+    whatsappMessage: '🚪 Olá! Gostaria de um orçamento para Divisórias de Ambiente.',
+  },
+  portaoAluminio: {
+    slug: 'portao-aluminio',
+    whatsappMessage: '🚪 Olá! Gostaria de um orçamento para Portões em alumínio.',
+  },
+  vidroTemperadoSobMedida: {
+    slug: 'vidro-temperado',
+    whatsappMessage: '✨ Olá! Gostaria de um orçamento para Vidros temperados sob medida.',
+  },
+  tampoMesa: {
+    slug: 'tampo-mesa',
+    whatsappMessage: '✨ Olá! Gostaria de um orçamento para Tampos de Mesa.',
+  },
+} as const;
+
+export const SERVICE_SLUGS = Object.values(SERVICE_TAXONOMY).map(({ slug }) => slug);
+
+/** Valores aceitos pelo guard do DOM final. */
+export const WHATSAPP_CONTEXTS = [
+  'floating-button',
+  'footer-whatsapp',
+  'sticky-cta',
+  'hero-whatsapp',
+  'service-card',
+  'service-gallery',
+  'cta-band',
+  'thank-you-page',
+  'avaliar-link-invalido',
+  'form-fallback',
+  'form-error',
+] as const;
+
+/** Rótulos do rodapé e da página de avaliação; copy preservada. */
 export const SERVICES = [
   'Box para Banheiro',
   'Sacadas Envidraçadas',
@@ -119,6 +183,19 @@ export const SERVICES = [
   'Espelhos',
   'Divisórias',
 ];
+
+const SERVICE_BY_LOCAL_LABEL = new Map([
+  ['Instalação de cortinas de vidro', SERVICE_TAXONOMY.sacadaEnvidracada],
+  ['Box blindex para banheiro', SERVICE_TAXONOMY.boxBanheiro],
+  ['Portas de vidro temperado', SERVICE_TAXONOMY.portasJanelas],
+  ['Guarda corpo em vidro', SERVICE_TAXONOMY.guardaCorpo],
+  ['Portões em alumínio', SERVICE_TAXONOMY.portaoAluminio],
+  ['Vidros temperados sob medida', SERVICE_TAXONOMY.vidroTemperadoSobMedida],
+]);
+
+export function serviceForLocalLabel(label: string) {
+  return SERVICE_BY_LOCAL_LABEL.get(label);
+}
 
 /** Opções do <select> do formulário — a ordem é a mesma do index atual. */
 export const NEIGHBORHOOD_OPTIONS = [

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,7 +1,13 @@
 ---
 import Icon from '../components/Icon.astro';
 import { getImage } from 'astro:assets';
-import { SITE_URL, ANALYTICS, CONTACT } from '../data/site';
+import {
+  SITE_URL,
+  ANALYTICS,
+  CONTACT,
+  SERVICE_SLUGS,
+  WHATSAPP_CONTEXTS,
+} from '../data/site';
 import lojaFrente from '../assets/loja-verly-realengo.png';
 import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
@@ -181,6 +187,8 @@ const ogImageUrl = ogImage ?? `${SITE_URL}${ogFallback.src}`;
     class={bodyClass}
     data-page-type={pageType}
     data-neighborhood-page={neighborhoodPage || undefined}
+    data-service-slugs={SERVICE_SLUGS.join(',')}
+    data-whatsapp-contexts={WHATSAPP_CONTEXTS.join(',')}
   >
     <header class="header">
       <div class="container">

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -1,7 +1,12 @@
 ---
 import Icon from '../components/Icon.astro';
 import Base from '../layouts/Base.astro';
-import { CONTACT, SITE_URL, GOOGLE_REVIEWS } from '../data/site';
+import {
+  CONTACT,
+  SITE_URL,
+  GOOGLE_REVIEWS,
+  serviceForLocalLabel,
+} from '../data/site';
 import QuoteForm from '../components/QuoteForm.astro';
 import { Image } from 'astro:assets';
 import lojaFrente from '../assets/loja-verly-realengo.png';
@@ -15,15 +20,14 @@ export function getStaticPaths() {
 
 const { n } = Astro.props;
 
-// O texto local é copy; data-service é o contrato estável usado pelo CTA.
-const serviceKeys: Record<string, string> = {
-  'Instalação de cortinas de vidro': 'cortinas-vidro',
-  'Box blindex para banheiro': 'box-blindex-banheiro',
-  'Portas de vidro temperado': 'portas-vidro-temperado',
-  'Guarda corpo em vidro': 'guarda-corpo-vidro',
-  'Portões em alumínio': 'portoes-aluminio',
-  'Vidros temperados sob medida': 'vidros-temperados-sob-medida',
-};
+// O texto local é copy; o slug canônico vem da taxonomia única de site.ts.
+const localServices = n.services.map((label: string) => {
+  const service = serviceForLocalLabel(label);
+  if (!service) {
+    throw new Error(`Serviço local sem taxonomia: "${label}" (${n.slug}).`);
+  }
+  return { label, service };
+});
 
 // FAQPage só entra quando o bairro realmente tem perguntas (hoje só Realengo).
 const faqSchema =
@@ -139,10 +143,10 @@ const faqSchema =
       {n.intro.map((p) => <p class="section-subtitle">{p}</p>)}
 
       <div class="services-grid">
-        {n.services.map((s) => (
-          <div class="service-card" data-service={serviceKeys[s]}>
+        {localServices.map(({ label, service }) => (
+          <div class="service-card" data-service={service.slug} data-whatsapp-message={service.whatsappMessage}>
             <div class="service-icon"><Icon name="check" /></div>
-            <h3>{s}</h3>
+            <h3>{label}</h3>
           </div>
         ))}
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,7 @@ import Base from '../layouts/Base.astro';
 import lojaFrente from '../assets/loja-verly-realengo.png';
 import QuoteForm from '../components/QuoteForm.astro';
 import ServiceGallery from '../components/ServiceGallery.astro';
-import { CONTACT, GOOGLE_REVIEWS } from '../data/site';
+import { CONTACT, GOOGLE_REVIEWS, SERVICE_TAXONOMY } from '../data/site';
 import { fetchPublishedReviews, idadeRelativa } from '../data/published-reviews';
 
 // Lidas no build. Devolve [] em qualquer falha, de propósito: o deploy da LP não pode
@@ -134,42 +134,42 @@ const initials = (name: string): string =>
                 Soluções completas em vidros temperados e alumínio para seu projeto
             </p>
             <div class="services-grid">
-                <div class="service-card" data-service="box-banheiro">
+                <div class="service-card" data-service={SERVICE_TAXONOMY.boxBanheiro.slug} data-whatsapp-message={SERVICE_TAXONOMY.boxBanheiro.whatsappMessage}>
                     <div class="service-icon">
                         <Icon name="box-canto" />
                     </div>
                     <h3>Box para Banheiro</h3>
                     <p>Box blindex com vidro temperado 8mm, acabamento premium e instalação rápida.</p>
                 </div>
-                <div class="service-card" data-service="sacada-envidracada">
+                <div class="service-card" data-service={SERVICE_TAXONOMY.sacadaEnvidracada.slug} data-whatsapp-message={SERVICE_TAXONOMY.sacadaEnvidracada.whatsappMessage}>
                     <div class="service-icon">
                         <Icon name="sacada-envidracada" />
                     </div>
                     <h3>Sacadas Envidraçadas</h3>
                     <p>Cortinas de vidro retráteis para sacadas e varandas com alta resistência.</p>
                 </div>
-                <div class="service-card" data-service="guarda-corpos-vidro">
+                <div class="service-card" data-service={SERVICE_TAXONOMY.guardaCorpo.slug} data-whatsapp-message={SERVICE_TAXONOMY.guardaCorpo.whatsappMessage}>
                     <div class="service-icon">
                         <Icon name="guarda-corpo" />
                     </div>
                     <h3>Guarda-corpos de Vidro</h3>
                     <p>Guarda-corpos modernos em vidro temperado para escadas e sacadas.</p>
                 </div>
-                <div class="service-card" data-service="portas-janelas">
+                <div class="service-card" data-service={SERVICE_TAXONOMY.portasJanelas.slug} data-whatsapp-message={SERVICE_TAXONOMY.portasJanelas.whatsappMessage}>
                     <div class="service-icon">
                         <Icon name="porta-janela-vidro" />
                     </div>
                     <h3>Portas e Janelas</h3>
                     <p>Portas e janelas de vidro temperado e alumínio sob medida.</p>
                 </div>
-                <div class="service-card" data-service="espelhos-sob-medida">
+                <div class="service-card" data-service={SERVICE_TAXONOMY.espelhoSobMedida.slug} data-whatsapp-message={SERVICE_TAXONOMY.espelhoSobMedida.whatsappMessage}>
                     <div class="service-icon">
                         <Icon name="espelho" />
                     </div>
                     <h3>Espelhos Sob Medida</h3>
                     <p>Espelhos com e sem moldura, instalação completa e acabamento perfeito.</p>
                 </div>
-                <div class="service-card" data-service="divisorias-ambiente">
+                <div class="service-card" data-service={SERVICE_TAXONOMY.divisoriaAmbiente.slug} data-whatsapp-message={SERVICE_TAXONOMY.divisoriaAmbiente.whatsappMessage}>
                     <div class="service-icon">
                         <Icon name="divisoria" />
                     </div>


### PR DESCRIPTION
## Summary
- define one canonical service taxonomy in `src/data/site.ts` and reuse it across home cards, neighborhood cards, the gallery, and form analytics
- keep CTA placement in `context` and send canonical service identity separately as `service`, so one physical service aggregates into one GA4 row
- validate every rendered `*.html` page with headless Chrome during `npm run build`, rejecting missing/invalid/unknown WhatsApp taxonomy values
- rewrite the obsolete GA4 guide and update the analytics plan for the resulting contract

## Why `context` + `service`
`context` now answers where the CTA was shown (`service-card` or `service-gallery`), while `service` answers what was requested (`guarda-corpo`). This preserves placement analysis without encoding placement into service identity. Impression deduplication now uses `context + service`, so multiple service cards do not collapse into one impression.

No CSS, layout, or copy changed. `ServiceGallery.astro` was touched only to source `data-context` and `data-service` from the new taxonomy.

## Rendered-DOM inventory
The baseline was built before editing. The same command was then run against the final build; Chrome executes the runtime code, so sticky and service-card links are included:

```sh
node --input-type=module <<'NODE'
import { execFileSync } from 'node:child_process';
const chrome = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
const pages = ['index', 'anil', 'realengo', 'avaliar', 'blog', 'obrigado'];
const all = new Set();
for (const page of pages) {
  const html = execFileSync(chrome, [
    '--headless', '--disable-gpu', '--dump-dom', '--virtual-time-budget=1000',
    `http://127.0.0.1:50830/${page}.html`
  ], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
  const contexts = [...html.matchAll(/data-context=\"([^\"]+)\"/g)].map((m) => m[1]);
  contexts.forEach((context) => all.add(context));
  console.log(`${page}.html: ${[...new Set(contexts)].join(', ')}`);
}
console.log(`ALL: ${[...all].sort().join(', ')}`);
NODE
```

| Page | Before | After |
|---|---|---|
| `index.html` | 16 links; 6 `service-*` and 5 `gallery-*` service-specific contexts | 16 links; service links use `service-card`/`service-gallery` plus canonical `service` |
| `anil.html` | 10 links; 6 service-specific contexts | 10 links; all six use `service-card` plus canonical `service` |
| `realengo.html` | 10 links; 6 service-specific contexts | 10 links; all six use `service-card` plus canonical `service` |

Final context inventory from the command:

```text
avaliar-link-invalido, cta-band, floating-button, footer-whatsapp,
hero-whatsapp, service-card, service-gallery, sticky-cta, thank-you-page
```

`form-fallback` and `form-error` are reachable only after their respective form delivery failures, so they do not exist in the default rendered DOM.

## Complete context migration
This is the complete before/after mapping, including the two runtime-only handoffs:

| Before `context` | After `context` | After `service` |
|---|---|---|
| `floating-button` | `floating-button` | — |
| `footer-whatsapp` | `footer-whatsapp` | — |
| `sticky-cta` | `sticky-cta` | — |
| `hero-whatsapp` | `hero-whatsapp` | — |
| `cta-band` | `cta-band` | — |
| `thank-you-page` | `thank-you-page` | — |
| `avaliar-link-invalido` | `avaliar-link-invalido` | — |
| `service-box-banheiro` | `service-card` | `box-banheiro` |
| `service-sacada` | `service-card` | `sacada` |
| `service-guarda-corpo` | `service-card` | `guarda-corpo` |
| `service-portas` | `service-card` | `portas-janelas` |
| `service-espelhos` | `service-card` | `espelho` |
| `service-divisórias` | `service-card` | `divisoria` |
| `service-cortinas-vidro` | `service-card` | `sacada` |
| `service-box-blindex-banheiro` | `service-card` | `box-banheiro` |
| `service-portas-vidro-temperado` | `service-card` | `portas-janelas` |
| `service-guarda-corpo-vidro` | `service-card` | `guarda-corpo` |
| `service-portoes-aluminio` | `service-card` | `portao-aluminio` |
| `service-vidros-temperados-sob-medida` | `service-card` | `vidro-temperado` |
| `gallery-box-banheiro` | `service-gallery` | `box-banheiro` |
| `gallery-sacada-envidracada` | `service-gallery` | `sacada` |
| `gallery-guarda-corpos-vidro` | `service-gallery` | `guarda-corpo` |
| `gallery-portas-janelas` | `service-gallery` | `portas-janelas` |
| `gallery-espelhos-sob-medida` | `service-gallery` | `espelho` |
| `form_fallback` | `form-fallback` | — |
| `form_error` | `form-error` | — |

The three old guard-rail rows for the same physical service now all aggregate under `service = guarda-corpo`:

```text
home card         service-card     guarda-corpo
gallery photo     service-gallery  guarda-corpo
neighborhood card service-card     guarda-corpo
```

## Guard failure proof
I deliberately changed the home hero to `data-context="hero_whatsapp"` and ran the complete build. It failed after rendering all pages with:

```text
✗ Taxonomia de WhatsApp inválida no DOM final:
  index.html link WhatsApp #1: context "hero_whatsapp" fora da convenção [a-z0-9-]
```

After reverting that planted value, the clean build passed:

```text
✓ Taxonomia de WhatsApp: 142 links em 17 páginas renderizadas
```

The guard recursively discovers HTML by file type rather than maintaining a page-name allowlist.

## Test plan
- [x] `npm ci && npm run build`
- [x] negative build with deliberately invalid context
- [x] final rendered-DOM inventory for home, two neighborhood pages, and the remaining distinct page types
- [x] confirmed no CSS, layout, or copy changes; screenshots are not applicable to this data-attribute-only change

Made with [Cursor](https://cursor.com)